### PR TITLE
fix(SDK): Findings and Notifications service now use AccountID as global param

### DIFF
--- a/findingsv1/findings_v1.go
+++ b/findingsv1/findings_v1.go
@@ -232,7 +232,7 @@ func (findings *FindingsV1) PostGraphWithContext(ctx context.Context, postGraphO
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*postGraphOptions.TransactionID))
 	}
 
-	_, err = builder.SetBodyContent(core.StringNilMapper(postGraphOptions.ContentType), postGraphOptions.Body, nil, postGraphOptions.Body)
+	_, err = builder.SetBodyContent(core.StringNilMapper(postGraphOptions.ContentType), nil, nil, postGraphOptions.Body)
 	if err != nil {
 		return
 	}

--- a/findingsv1/findings_v1_examples_test.go
+++ b/findingsv1/findings_v1_examples_test.go
@@ -84,7 +84,9 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 
 			// begin-common
 
-			findingsServiceOptions := &findingsv1.FindingsV1Options{}
+			findingsServiceOptions := &findingsv1.FindingsV1Options{
+				AccountID: core.StringPtr("testString"),
+			}
 
 			findingsService, err = findingsv1.NewFindingsV1UsingExternalConfig(findingsServiceOptions)
 
@@ -105,9 +107,7 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 		It(`PostGraph request example`, func() {
 			// begin-postGraph
 
-			postGraphOptions := findingsService.NewPostGraphOptions(
-				"testString",
-			)
+			postGraphOptions := findingsService.NewPostGraphOptions()
 			postGraphOptions.SetBody(CreateMockReader("This is a mock file."))
 
 			response, err := findingsService.PostGraph(postGraphOptions)
@@ -132,7 +132,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			}
 
 			createNoteOptions := findingsService.NewCreateNoteOptions(
-				"testString",
 				"testString",
 				"testString",
 				"testString",
@@ -161,7 +160,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 
 			listNotesOptions := findingsService.NewListNotesOptions(
 				"testString",
-				"testString",
 			)
 
 			apiListNotesResponse, response, err := findingsService.ListNotes(listNotesOptions)
@@ -183,7 +181,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			// begin-getNote
 
 			getNoteOptions := findingsService.NewGetNoteOptions(
-				"testString",
 				"testString",
 				"testString",
 			)
@@ -216,7 +213,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 				"testString",
 				"testString",
 				"testString",
-				"testString",
 				"FINDING",
 				"testString",
 				reporterModel,
@@ -243,7 +239,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			getOccurrenceNoteOptions := findingsService.NewGetOccurrenceNoteOptions(
 				"testString",
 				"testString",
-				"testString",
 			)
 
 			apiNote, response, err := findingsService.GetOccurrenceNote(getOccurrenceNoteOptions)
@@ -265,7 +260,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			// begin-createOccurrence
 
 			createOccurrenceOptions := findingsService.NewCreateOccurrenceOptions(
-				"testString",
 				"testString",
 				"testString",
 				"FINDING",
@@ -292,7 +286,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 
 			listOccurrencesOptions := findingsService.NewListOccurrencesOptions(
 				"testString",
-				"testString",
 			)
 
 			apiListOccurrencesResponse, response, err := findingsService.ListOccurrences(listOccurrencesOptions)
@@ -316,7 +309,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			listNoteOccurrencesOptions := findingsService.NewListNoteOccurrencesOptions(
 				"testString",
 				"testString",
-				"testString",
 			)
 
 			apiListNoteOccurrencesResponse, response, err := findingsService.ListNoteOccurrences(listNoteOccurrencesOptions)
@@ -338,7 +330,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			// begin-getOccurrence
 
 			getOccurrenceOptions := findingsService.NewGetOccurrenceOptions(
-				"testString",
 				"testString",
 				"testString",
 			)
@@ -365,7 +356,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 				"testString",
 				"testString",
 				"testString",
-				"testString",
 				"FINDING",
 				"testString",
 			)
@@ -388,9 +378,7 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			fmt.Println("\nListProviders() result:")
 			// begin-listProviders
 
-			listProvidersOptions := findingsService.NewListProvidersOptions(
-				"testString",
-			)
+			listProvidersOptions := findingsService.NewListProvidersOptions()
 
 			apiListProvidersResponse, response, err := findingsService.ListProviders(listProvidersOptions)
 			if err != nil {
@@ -412,7 +400,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			deleteOccurrenceOptions := findingsService.NewDeleteOccurrenceOptions(
 				"testString",
 				"testString",
-				"testString",
 			)
 
 			response, err := findingsService.DeleteOccurrence(deleteOccurrenceOptions)
@@ -431,7 +418,6 @@ var _ = Describe(`FindingsV1 Examples Tests`, func() {
 			// begin-deleteNote
 
 			deleteNoteOptions := findingsService.NewDeleteNoteOptions(
-				"testString",
 				"testString",
 				"testString",
 			)

--- a/findingsv1/findings_v1_integration_test.go
+++ b/findingsv1/findings_v1_integration_test.go
@@ -95,7 +95,9 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		})
 		It("Successfully construct the service client instance", func() {
 
-			findingsServiceOptions := &findingsv1.FindingsV1Options{}
+			findingsServiceOptions := &findingsv1.FindingsV1Options{
+				AccountID: core.StringPtr(accountID),
+			}
 
 			findingsService, err = findingsv1.NewFindingsV1UsingExternalConfig(findingsServiceOptions)
 
@@ -112,7 +114,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`PostGraph(postGraphOptions *PostGraphOptions)`, func() {
 
 			postGraphOptions := &findingsv1.PostGraphOptions{
-				AccountID:   &accountID,
 				Body:        CreateMockReader(`{notes{id}}`),
 				ContentType: core.StringPtr("application/graphql"),
 			}
@@ -153,7 +154,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createNoteOptions := &findingsv1.CreateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				ShortDescription: &testString,
 				LongDescription:  &testString,
@@ -192,7 +192,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createNoteOptions := &findingsv1.CreateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				ShortDescription: &testString,
 				LongDescription:  &testString,
@@ -252,7 +251,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createNoteOptions := &findingsv1.CreateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				ShortDescription: &testString,
 				LongDescription:  &testString,
@@ -291,7 +289,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createNoteOptions := &findingsv1.CreateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				ShortDescription: &testString,
 				LongDescription:  &testString,
@@ -319,7 +316,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`ListNotes(listNotesOptions *ListNotesOptions)`, func() {
 
 			listNotesOptions := &findingsv1.ListNotesOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 			}
 
@@ -339,7 +335,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`GetNote(getNoteOptions *GetNoteOptions)`, func() {
 
 			getNoteOptions := &findingsv1.GetNoteOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 				NoteID:     core.StringPtr(fmt.Sprintf("finding-note-%s", identifier)),
 			}
@@ -381,7 +376,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateNoteOptions := &findingsv1.UpdateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				NoteID:           core.StringPtr(fmt.Sprintf("finding-note-%s", identifier)),
 				ShortDescription: &testString,
@@ -421,7 +415,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateNoteOptions := &findingsv1.UpdateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				NoteID:           core.StringPtr(fmt.Sprintf("kpi-note-%s", identifier)),
 				ShortDescription: &testString,
@@ -481,7 +474,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateNoteOptions := &findingsv1.UpdateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				NoteID:           core.StringPtr(fmt.Sprintf("card-note-%s", identifier)),
 				ShortDescription: &testString,
@@ -520,7 +512,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateNoteOptions := &findingsv1.UpdateNoteOptions{
-				AccountID:        &accountID,
 				ProviderID:       &providerID,
 				NoteID:           core.StringPtr(fmt.Sprintf("section-note-%s", identifier)),
 				ShortDescription: &testString,
@@ -594,7 +585,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createOccurrenceOptions := &findingsv1.CreateOccurrenceOptions{
-				AccountID:       &accountID,
 				ProviderID:      &providerID,
 				NoteName:        core.StringPtr(fmt.Sprintf("%s/providers/%s/notes/finding-note-%s", accountID, providerID, identifier)),
 				Kind:            core.StringPtr("FINDING"),
@@ -640,7 +630,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			createOccurrenceOptions := &findingsv1.CreateOccurrenceOptions{
-				AccountID:       &accountID,
 				ProviderID:      &providerID,
 				NoteName:        core.StringPtr(fmt.Sprintf("%s/providers/%s/notes/kpi-note-%s", accountID, providerID, identifier)),
 				Kind:            core.StringPtr("KPI"),
@@ -668,7 +657,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`GetOccurrenceNote(getOccurrenceNoteOptions *GetOccurrenceNoteOptions)`, func() {
 
 			getOccurrenceNoteOptions := &findingsv1.GetOccurrenceNoteOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: core.StringPtr(fmt.Sprintf("finding-occurrence-%s", identifier)),
 			}
@@ -689,7 +677,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`ListOccurrences(listOccurrencesOptions *ListOccurrencesOptions)`, func() {
 
 			listOccurrencesOptions := &findingsv1.ListOccurrencesOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 			}
 
@@ -709,7 +696,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`ListNoteOccurrences(listNoteOccurrencesOptions *ListNoteOccurrencesOptions)`, func() {
 
 			listNoteOccurrencesOptions := &findingsv1.ListNoteOccurrencesOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 				NoteID:     core.StringPtr(fmt.Sprintf("finding-note-%s", identifier)),
 			}
@@ -730,7 +716,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`GetOccurrence(getOccurrenceOptions *GetOccurrenceOptions)`, func() {
 
 			getOccurrenceOptions := &findingsv1.GetOccurrenceOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: core.StringPtr(fmt.Sprintf("finding-occurrence-%s", identifier)),
 			}
@@ -796,7 +781,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateOccurrenceOptions := &findingsv1.UpdateOccurrenceOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: core.StringPtr(fmt.Sprintf("finding-occurrence-%s", identifier)),
 				NoteName:     core.StringPtr(fmt.Sprintf("%s/providers/%s/notes/finding-note-%s", accountID, providerID, identifier)),
@@ -842,7 +826,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 			}
 
 			updateOccurrenceOptions := &findingsv1.UpdateOccurrenceOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: core.StringPtr(fmt.Sprintf("kpi-occurrence-%s", identifier)),
 				NoteName:     core.StringPtr(fmt.Sprintf("%s/providers/%s/notes/kpi-note-%s", accountID, providerID, identifier)),
@@ -869,9 +852,7 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		})
 		It(`ListProviders(listProvidersOptions *ListProvidersOptions)`, func() {
 
-			listProvidersOptions := &findingsv1.ListProvidersOptions{
-				AccountID: &accountID,
-			}
+			listProvidersOptions := &findingsv1.ListProvidersOptions{}
 
 			apiListProvidersResponse, response, err := findingsService.ListProviders(listProvidersOptions)
 
@@ -889,7 +870,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`DeleteOccurrence(deleteOccurrenceOptions *DeleteOccurrenceOptions)`, func() {
 
 			deleteOccurrenceOptions := &findingsv1.DeleteOccurrenceOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: core.StringPtr(fmt.Sprintf("finding-occurrence-%s", identifier)),
 			}
@@ -909,7 +889,6 @@ var _ = Describe(`FindingsV1 Integration Tests`, func() {
 		It(`DeleteNote(deleteNoteOptions *DeleteNoteOptions)`, func() {
 
 			deleteNoteOptions := &findingsv1.DeleteNoteOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 				NoteID:     core.StringPtr(fmt.Sprintf("section-note-%s", identifier)),
 			}
@@ -946,13 +925,14 @@ var _ = AfterSuite(func() {
 
 	fmt.Printf("cleaning up account: %s with provider: %s\n", accountID, providerID)
 
-	findingsServiceOptions := &findingsv1.FindingsV1Options{}
+	findingsServiceOptions := &findingsv1.FindingsV1Options{
+		AccountID: core.StringPtr(accountID),
+	}
 
 	findingsService, err := findingsv1.NewFindingsV1UsingExternalConfig(findingsServiceOptions)
 
 	// list notes and delete one by one
 	listNotesOptions := &findingsv1.ListNotesOptions{
-		AccountID:  &accountID,
 		ProviderID: &providerID,
 	}
 
@@ -965,7 +945,6 @@ var _ = AfterSuite(func() {
 		parts := strings.Split(*note.ID, "-")
 		if parts[len(parts)-1] == identifier {
 			deleteNoteOptions := &findingsv1.DeleteNoteOptions{
-				AccountID:  &accountID,
 				ProviderID: &providerID,
 				NoteID:     note.ID,
 			}
@@ -978,7 +957,6 @@ var _ = AfterSuite(func() {
 
 	// list occurrences and delete one by one
 	listOccurrencesOptions := &findingsv1.ListOccurrencesOptions{
-		AccountID:  &accountID,
 		ProviderID: &providerID,
 	}
 
@@ -991,7 +969,6 @@ var _ = AfterSuite(func() {
 		parts := strings.Split(*occurrence.ID, "-")
 		if parts[len(parts)-1] == identifier {
 			deleteOccurrenceOptions := &findingsv1.DeleteOccurrenceOptions{
-				AccountID:    &accountID,
 				ProviderID:   &providerID,
 				OccurrenceID: occurrence.ID,
 			}
@@ -1005,9 +982,7 @@ var _ = AfterSuite(func() {
 	fmt.Printf("cleanup was successful\n")
 
 	// cross checking if the provider is there or not
-	listProvidersOptions := &findingsv1.ListProvidersOptions{
-		AccountID: &accountID,
-	}
+	listProvidersOptions := &findingsv1.ListProvidersOptions{}
 
 	apiListProvidersResponse, _, err := findingsService.ListProviders(listProvidersOptions)
 	for _, provider := range apiListProvidersResponse.Providers {

--- a/notificationsv1/notifications_v1.go
+++ b/notificationsv1/notifications_v1.go
@@ -38,6 +38,9 @@ import (
 // Version: 1.0.0
 type NotificationsV1 struct {
 	Service *core.BaseService
+
+	// Account ID.
+	AccountID *string
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
@@ -51,6 +54,9 @@ type NotificationsV1Options struct {
 	ServiceName   string
 	URL           string
 	Authenticator core.Authenticator
+
+	// Account ID.
+	AccountID *string `validate:"required"`
 }
 
 // NewNotificationsV1UsingExternalConfig : constructs an instance of NotificationsV1 with passed in options and external configuration.
@@ -89,6 +95,11 @@ func NewNotificationsV1(options *NotificationsV1Options) (service *Notifications
 		Authenticator: options.Authenticator,
 	}
 
+	err = core.ValidateStruct(options, "options")
+	if err != nil {
+		return
+	}
+
 	baseService, err := core.NewBaseService(serviceOptions)
 	if err != nil {
 		return
@@ -102,7 +113,8 @@ func NewNotificationsV1(options *NotificationsV1Options) (service *Notifications
 	}
 
 	service = &NotificationsV1{
-		Service: baseService,
+		Service:   baseService,
+		AccountID: options.AccountID,
 	}
 
 	return
@@ -177,17 +189,13 @@ func (notifications *NotificationsV1) ListAllChannels(listAllChannelsOptions *Li
 
 // ListAllChannelsWithContext is an alternate form of the ListAllChannels method which supports a Context parameter
 func (notifications *NotificationsV1) ListAllChannelsWithContext(ctx context.Context, listAllChannelsOptions *ListAllChannelsOptions) (result *ChannelsList, response *core.DetailedResponse, err error) {
-	err = core.ValidateNotNil(listAllChannelsOptions, "listAllChannelsOptions cannot be nil")
-	if err != nil {
-		return
-	}
 	err = core.ValidateStruct(listAllChannelsOptions, "listAllChannelsOptions")
 	if err != nil {
 		return
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *listAllChannelsOptions.AccountID,
+		"account_id": *notifications.AccountID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -257,7 +265,7 @@ func (notifications *NotificationsV1) CreateNotificationChannelWithContext(ctx c
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *createNotificationChannelOptions.AccountID,
+		"account_id": *notifications.AccountID,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
@@ -348,7 +356,7 @@ func (notifications *NotificationsV1) DeleteNotificationChannelsWithContext(ctx 
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *deleteNotificationChannelsOptions.AccountID,
+		"account_id": *notifications.AccountID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -417,7 +425,7 @@ func (notifications *NotificationsV1) DeleteNotificationChannelWithContext(ctx c
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *deleteNotificationChannelOptions.AccountID,
+		"account_id": *notifications.AccountID,
 		"channel_id": *deleteNotificationChannelOptions.ChannelID,
 	}
 
@@ -481,7 +489,7 @@ func (notifications *NotificationsV1) GetNotificationChannelWithContext(ctx cont
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *getNotificationChannelOptions.AccountID,
+		"account_id": *notifications.AccountID,
 		"channel_id": *getNotificationChannelOptions.ChannelID,
 	}
 
@@ -545,7 +553,7 @@ func (notifications *NotificationsV1) UpdateNotificationChannelWithContext(ctx c
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *updateNotificationChannelOptions.AccountID,
+		"account_id": *notifications.AccountID,
 		"channel_id": *updateNotificationChannelOptions.ChannelID,
 	}
 
@@ -637,7 +645,7 @@ func (notifications *NotificationsV1) TestNotificationChannelWithContext(ctx con
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *testNotificationChannelOptions.AccountID,
+		"account_id": *notifications.AccountID,
 		"channel_id": *testNotificationChannelOptions.ChannelID,
 	}
 
@@ -691,17 +699,13 @@ func (notifications *NotificationsV1) GetPublicKey(getPublicKeyOptions *GetPubli
 
 // GetPublicKeyWithContext is an alternate form of the GetPublicKey method which supports a Context parameter
 func (notifications *NotificationsV1) GetPublicKeyWithContext(ctx context.Context, getPublicKeyOptions *GetPublicKeyOptions) (result *PublicKeyGet, response *core.DetailedResponse, err error) {
-	err = core.ValidateNotNil(getPublicKeyOptions, "getPublicKeyOptions cannot be nil")
-	if err != nil {
-		return
-	}
 	err = core.ValidateStruct(getPublicKeyOptions, "getPublicKeyOptions")
 	if err != nil {
 		return
 	}
 
 	pathParamsMap := map[string]string{
-		"account_id": *getPublicKeyOptions.AccountID,
+		"account_id": *notifications.AccountID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -924,9 +928,6 @@ func UnmarshalChannelsList(m map[string]json.RawMessage, result interface{}) (er
 
 // CreateNotificationChannelOptions : The CreateNotificationChannel options.
 type CreateNotificationChannelOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// The name of the notification channel in the form "v1/{account_id}/notifications/channelName".
 	Name *string `validate:"required"`
 
@@ -969,19 +970,12 @@ const (
 )
 
 // NewCreateNotificationChannelOptions : Instantiate CreateNotificationChannelOptions
-func (*NotificationsV1) NewCreateNotificationChannelOptions(accountID string, name string, typeVar string, endpoint string) *CreateNotificationChannelOptions {
+func (*NotificationsV1) NewCreateNotificationChannelOptions(name string, typeVar string, endpoint string) *CreateNotificationChannelOptions {
 	return &CreateNotificationChannelOptions{
-		AccountID: core.StringPtr(accountID),
-		Name:      core.StringPtr(name),
-		Type:      core.StringPtr(typeVar),
-		Endpoint:  core.StringPtr(endpoint),
+		Name:     core.StringPtr(name),
+		Type:     core.StringPtr(typeVar),
+		Endpoint: core.StringPtr(endpoint),
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *CreateNotificationChannelOptions) SetAccountID(accountID string) *CreateNotificationChannelOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetName : Allow user to set Name
@@ -1040,9 +1034,6 @@ func (options *CreateNotificationChannelOptions) SetHeaders(param map[string]str
 
 // DeleteNotificationChannelOptions : The DeleteNotificationChannel options.
 type DeleteNotificationChannelOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// Channel ID.
 	ChannelID *string `validate:"required,ne="`
 
@@ -1054,17 +1045,10 @@ type DeleteNotificationChannelOptions struct {
 }
 
 // NewDeleteNotificationChannelOptions : Instantiate DeleteNotificationChannelOptions
-func (*NotificationsV1) NewDeleteNotificationChannelOptions(accountID string, channelID string) *DeleteNotificationChannelOptions {
+func (*NotificationsV1) NewDeleteNotificationChannelOptions(channelID string) *DeleteNotificationChannelOptions {
 	return &DeleteNotificationChannelOptions{
-		AccountID: core.StringPtr(accountID),
 		ChannelID: core.StringPtr(channelID),
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *DeleteNotificationChannelOptions) SetAccountID(accountID string) *DeleteNotificationChannelOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetChannelID : Allow user to set ChannelID
@@ -1087,9 +1071,6 @@ func (options *DeleteNotificationChannelOptions) SetHeaders(param map[string]str
 
 // DeleteNotificationChannelsOptions : The DeleteNotificationChannels options.
 type DeleteNotificationChannelsOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// Body for bulk delete notification channels.
 	Body []string `validate:"required"`
 
@@ -1101,17 +1082,10 @@ type DeleteNotificationChannelsOptions struct {
 }
 
 // NewDeleteNotificationChannelsOptions : Instantiate DeleteNotificationChannelsOptions
-func (*NotificationsV1) NewDeleteNotificationChannelsOptions(accountID string, body []string) *DeleteNotificationChannelsOptions {
+func (*NotificationsV1) NewDeleteNotificationChannelsOptions(body []string) *DeleteNotificationChannelsOptions {
 	return &DeleteNotificationChannelsOptions{
-		AccountID: core.StringPtr(accountID),
-		Body:      body,
+		Body: body,
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *DeleteNotificationChannelsOptions) SetAccountID(accountID string) *DeleteNotificationChannelsOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetBody : Allow user to set Body
@@ -1134,9 +1108,6 @@ func (options *DeleteNotificationChannelsOptions) SetHeaders(param map[string]st
 
 // GetNotificationChannelOptions : The GetNotificationChannel options.
 type GetNotificationChannelOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// Channel ID.
 	ChannelID *string `validate:"required,ne="`
 
@@ -1148,17 +1119,10 @@ type GetNotificationChannelOptions struct {
 }
 
 // NewGetNotificationChannelOptions : Instantiate GetNotificationChannelOptions
-func (*NotificationsV1) NewGetNotificationChannelOptions(accountID string, channelID string) *GetNotificationChannelOptions {
+func (*NotificationsV1) NewGetNotificationChannelOptions(channelID string) *GetNotificationChannelOptions {
 	return &GetNotificationChannelOptions{
-		AccountID: core.StringPtr(accountID),
 		ChannelID: core.StringPtr(channelID),
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *GetNotificationChannelOptions) SetAccountID(accountID string) *GetNotificationChannelOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetChannelID : Allow user to set ChannelID
@@ -1181,9 +1145,6 @@ func (options *GetNotificationChannelOptions) SetHeaders(param map[string]string
 
 // GetPublicKeyOptions : The GetPublicKey options.
 type GetPublicKeyOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// The transaction id for the request in uuid v4 format.
 	TransactionID *string
 
@@ -1192,16 +1153,8 @@ type GetPublicKeyOptions struct {
 }
 
 // NewGetPublicKeyOptions : Instantiate GetPublicKeyOptions
-func (*NotificationsV1) NewGetPublicKeyOptions(accountID string) *GetPublicKeyOptions {
-	return &GetPublicKeyOptions{
-		AccountID: core.StringPtr(accountID),
-	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *GetPublicKeyOptions) SetAccountID(accountID string) *GetPublicKeyOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
+func (*NotificationsV1) NewGetPublicKeyOptions() *GetPublicKeyOptions {
+	return &GetPublicKeyOptions{}
 }
 
 // SetTransactionID : Allow user to set TransactionID
@@ -1218,9 +1171,6 @@ func (options *GetPublicKeyOptions) SetHeaders(param map[string]string) *GetPubl
 
 // ListAllChannelsOptions : The ListAllChannels options.
 type ListAllChannelsOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// The transaction id for the request in uuid v4 format.
 	TransactionID *string
 
@@ -1235,16 +1185,8 @@ type ListAllChannelsOptions struct {
 }
 
 // NewListAllChannelsOptions : Instantiate ListAllChannelsOptions
-func (*NotificationsV1) NewListAllChannelsOptions(accountID string) *ListAllChannelsOptions {
-	return &ListAllChannelsOptions{
-		AccountID: core.StringPtr(accountID),
-	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *ListAllChannelsOptions) SetAccountID(accountID string) *ListAllChannelsOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
+func (*NotificationsV1) NewListAllChannelsOptions() *ListAllChannelsOptions {
+	return &ListAllChannelsOptions{}
 }
 
 // SetTransactionID : Allow user to set TransactionID
@@ -1359,9 +1301,6 @@ func UnmarshalTestChannel(m map[string]json.RawMessage, result interface{}) (err
 
 // TestNotificationChannelOptions : The TestNotificationChannel options.
 type TestNotificationChannelOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// Channel ID.
 	ChannelID *string `validate:"required,ne="`
 
@@ -1373,17 +1312,10 @@ type TestNotificationChannelOptions struct {
 }
 
 // NewTestNotificationChannelOptions : Instantiate TestNotificationChannelOptions
-func (*NotificationsV1) NewTestNotificationChannelOptions(accountID string, channelID string) *TestNotificationChannelOptions {
+func (*NotificationsV1) NewTestNotificationChannelOptions(channelID string) *TestNotificationChannelOptions {
 	return &TestNotificationChannelOptions{
-		AccountID: core.StringPtr(accountID),
 		ChannelID: core.StringPtr(channelID),
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *TestNotificationChannelOptions) SetAccountID(accountID string) *TestNotificationChannelOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetChannelID : Allow user to set ChannelID
@@ -1406,9 +1338,6 @@ func (options *TestNotificationChannelOptions) SetHeaders(param map[string]strin
 
 // UpdateNotificationChannelOptions : The UpdateNotificationChannel options.
 type UpdateNotificationChannelOptions struct {
-	// Account ID.
-	AccountID *string `validate:"required,ne="`
-
 	// Channel ID.
 	ChannelID *string `validate:"required,ne="`
 
@@ -1454,20 +1383,13 @@ const (
 )
 
 // NewUpdateNotificationChannelOptions : Instantiate UpdateNotificationChannelOptions
-func (*NotificationsV1) NewUpdateNotificationChannelOptions(accountID string, channelID string, name string, typeVar string, endpoint string) *UpdateNotificationChannelOptions {
+func (*NotificationsV1) NewUpdateNotificationChannelOptions(channelID string, name string, typeVar string, endpoint string) *UpdateNotificationChannelOptions {
 	return &UpdateNotificationChannelOptions{
-		AccountID: core.StringPtr(accountID),
 		ChannelID: core.StringPtr(channelID),
 		Name:      core.StringPtr(name),
 		Type:      core.StringPtr(typeVar),
 		Endpoint:  core.StringPtr(endpoint),
 	}
-}
-
-// SetAccountID : Allow user to set AccountID
-func (_options *UpdateNotificationChannelOptions) SetAccountID(accountID string) *UpdateNotificationChannelOptions {
-	_options.AccountID = core.StringPtr(accountID)
-	return _options
 }
 
 // SetChannelID : Allow user to set ChannelID

--- a/notificationsv1/notifications_v1_examples_test.go
+++ b/notificationsv1/notifications_v1_examples_test.go
@@ -84,7 +84,9 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 
 			// begin-common
 
-			notificationsServiceOptions := &notificationsv1.NotificationsV1Options{}
+			notificationsServiceOptions := &notificationsv1.NotificationsV1Options{
+				AccountID: core.StringPtr("testString"),
+			}
 
 			notificationsService, err = notificationsv1.NewNotificationsV1UsingExternalConfig(notificationsServiceOptions)
 
@@ -106,9 +108,7 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			fmt.Println("\nListAllChannels() result:")
 			// begin-listAllChannels
 
-			listAllChannelsOptions := notificationsService.NewListAllChannelsOptions(
-				"testString",
-			)
+			listAllChannelsOptions := notificationsService.NewListAllChannelsOptions()
 
 			channelsList, response, err := notificationsService.ListAllChannels(listAllChannelsOptions)
 			if err != nil {
@@ -129,7 +129,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			// begin-createNotificationChannel
 
 			createNotificationChannelOptions := notificationsService.NewCreateNotificationChannelOptions(
-				"testString",
 				"testString",
 				"Webhook",
 				"testString",
@@ -155,7 +154,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 
 			getNotificationChannelOptions := notificationsService.NewGetNotificationChannelOptions(
 				"testString",
-				"testString",
 			)
 
 			channelGet, response, err := notificationsService.GetNotificationChannel(getNotificationChannelOptions)
@@ -177,7 +175,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			// begin-updateNotificationChannel
 
 			updateNotificationChannelOptions := notificationsService.NewUpdateNotificationChannelOptions(
-				"testString",
 				"testString",
 				"testString",
 				"Webhook",
@@ -204,7 +201,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 
 			testNotificationChannelOptions := notificationsService.NewTestNotificationChannelOptions(
 				"testString",
-				"testString",
 			)
 
 			testChannel, response, err := notificationsService.TestNotificationChannel(testNotificationChannelOptions)
@@ -225,9 +221,7 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			fmt.Println("\nGetPublicKey() result:")
 			// begin-getPublicKey
 
-			getPublicKeyOptions := notificationsService.NewGetPublicKeyOptions(
-				"testString",
-			)
+			getPublicKeyOptions := notificationsService.NewGetPublicKeyOptions()
 
 			publicKeyGet, response, err := notificationsService.GetPublicKey(getPublicKeyOptions)
 			if err != nil {
@@ -248,7 +242,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			// begin-deleteNotificationChannels
 
 			deleteNotificationChannelsOptions := notificationsService.NewDeleteNotificationChannelsOptions(
-				"testString",
 				[]string{"testString"},
 			)
 
@@ -271,7 +264,6 @@ var _ = Describe(`NotificationsV1 Examples Tests`, func() {
 			// begin-deleteNotificationChannel
 
 			deleteNotificationChannelOptions := notificationsService.NewDeleteNotificationChannelOptions(
-				"testString",
 				"testString",
 			)
 

--- a/notificationsv1/notifications_v1_integration_test.go
+++ b/notificationsv1/notifications_v1_integration_test.go
@@ -90,7 +90,9 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		})
 		It("Successfully construct the service client instance", func() {
 
-			notificationsServiceOptions := &notificationsv1.NotificationsV1Options{}
+			notificationsServiceOptions := &notificationsv1.NotificationsV1Options{
+				AccountID: core.StringPtr(accountID),
+			}
 
 			notificationsService, err = notificationsv1.NewNotificationsV1UsingExternalConfig(notificationsServiceOptions)
 
@@ -106,9 +108,7 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		})
 		It(`ListAllChannels(listAllChannelsOptions *ListAllChannelsOptions)`, func() {
 
-			listAllChannelsOptions := &notificationsv1.ListAllChannelsOptions{
-				AccountID: &accountID,
-			}
+			listAllChannelsOptions := &notificationsv1.ListAllChannelsOptions{}
 
 			channelsList, response, err := notificationsService.ListAllChannels(listAllChannelsOptions)
 
@@ -131,7 +131,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 			}
 
 			createNotificationChannelOptions := &notificationsv1.CreateNotificationChannelOptions{
-				AccountID:   &accountID,
 				Name:        core.StringPtr(fmt.Sprintf("%s-%s", testString, identifier)),
 				Type:        core.StringPtr("Webhook"),
 				Endpoint:    core.StringPtr("https://webhook.site/136fe1e2-3c3f-4bff-925f-391fbb202546"),
@@ -159,7 +158,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		It(`GetNotificationChannel(getNotificationChannelOptions *GetNotificationChannelOptions)`, func() {
 
 			getNotificationChannelOptions := &notificationsv1.GetNotificationChannelOptions{
-				AccountID: &accountID,
 				ChannelID: &channelID,
 			}
 
@@ -184,7 +182,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 			}
 
 			updateNotificationChannelOptions := &notificationsv1.UpdateNotificationChannelOptions{
-				AccountID:   &accountID,
 				ChannelID:   &channelID,
 				Name:        core.StringPtr(fmt.Sprintf("%s-%s", testString, identifier)),
 				Type:        core.StringPtr("Webhook"),
@@ -211,7 +208,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		It(`TestNotificationChannel(testNotificationChannelOptions *TestNotificationChannelOptions)`, func() {
 
 			testNotificationChannelOptions := &notificationsv1.TestNotificationChannelOptions{
-				AccountID: &accountID,
 				ChannelID: &channelID,
 			}
 
@@ -230,9 +226,7 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		})
 		It(`GetPublicKey(getPublicKeyOptions *GetPublicKeyOptions)`, func() {
 
-			getPublicKeyOptions := &notificationsv1.GetPublicKeyOptions{
-				AccountID: &accountID,
-			}
+			getPublicKeyOptions := &notificationsv1.GetPublicKeyOptions{}
 
 			publicKeyGet, response, err := notificationsService.GetPublicKey(getPublicKeyOptions)
 
@@ -250,7 +244,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		It(`DeleteNotificationChannel(deleteNotificationChannelOptions *DeleteNotificationChannelOptions)`, func() {
 
 			deleteNotificationChannelOptions := &notificationsv1.DeleteNotificationChannelOptions{
-				AccountID: &accountID,
 				ChannelID: &channelID,
 			}
 
@@ -270,7 +263,6 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 		It(`DeleteNotificationChannels(deleteNotificationChannelsOptions *DeleteNotificationChannelsOptions)`, func() {
 
 			createNotificationChannelOptions := &notificationsv1.CreateNotificationChannelOptions{
-				AccountID:   &accountID,
 				Name:        core.StringPtr(fmt.Sprintf("%s-%s", testString, identifier)),
 				Type:        core.StringPtr("Webhook"),
 				Endpoint:    core.StringPtr("https://webhook.site/136fe1e2-3c3f-4bff-925f-391fbb202546"),
@@ -284,8 +276,7 @@ var _ = Describe(`NotificationsV1 Integration Tests`, func() {
 			channelID = *channelInfo.ChannelID
 
 			deleteNotificationChannelsOptions := &notificationsv1.DeleteNotificationChannelsOptions{
-				AccountID: &accountID,
-				Body:      []string{channelID},
+				Body: []string{channelID},
 			}
 
 			channelsDelete, response, err := notificationsService.DeleteNotificationChannels(deleteNotificationChannelsOptions)
@@ -321,13 +312,13 @@ var _ = AfterSuite(func() {
 
 	fmt.Printf("cleaning up account: %s\n", accountID)
 
-	notificationsServiceOptions := &notificationsv1.NotificationsV1Options{}
+	notificationsServiceOptions := &notificationsv1.NotificationsV1Options{
+		AccountID: core.StringPtr(accountID),
+	}
 
 	notificationsService, err := notificationsv1.NewNotificationsV1UsingExternalConfig(notificationsServiceOptions)
 
-	listAllChannelsOptions := &notificationsv1.ListAllChannelsOptions{
-		AccountID: &accountID,
-	}
+	listAllChannelsOptions := &notificationsv1.ListAllChannelsOptions{}
 
 	channels, _, err := notificationsService.ListAllChannels(listAllChannelsOptions)
 	if err != nil {
@@ -337,7 +328,6 @@ var _ = AfterSuite(func() {
 	for _, channel := range channels.Channels {
 		if *channel.ChannelID == channelID {
 			deleteNotificationChannelOptions := &notificationsv1.DeleteNotificationChannelOptions{
-				AccountID: &accountID,
 				ChannelID: channel.ChannelID,
 			}
 

--- a/notificationsv1/notifications_v1_test.go
+++ b/notificationsv1/notifications_v1_test.go
@@ -37,23 +37,27 @@ import (
 var _ = Describe(`NotificationsV1`, func() {
 	var testServer *httptest.Server
 	Describe(`Service constructor tests`, func() {
+		accountID := "testString"
 		It(`Instantiate service client`, func() {
 			notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 				Authenticator: &core.NoAuthAuthenticator{},
+				AccountID:     core.StringPtr(accountID),
 			})
 			Expect(notificationsService).ToNot(BeNil())
 			Expect(serviceErr).To(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid URL`, func() {
 			notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
-				URL: "{BAD_URL_STRING",
+				URL:       "{BAD_URL_STRING",
+				AccountID: core.StringPtr(accountID),
 			})
 			Expect(notificationsService).To(BeNil())
 			Expect(serviceErr).ToNot(BeNil())
 		})
 		It(`Instantiate service client with error: Invalid Auth`, func() {
 			notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
-				URL: "https://notificationsv1/api",
+				URL:       "https://notificationsv1/api",
+				AccountID: core.StringPtr(accountID),
 				Authenticator: &core.BasicAuthenticator{
 					Username: "",
 					Password: "",
@@ -62,8 +66,14 @@ var _ = Describe(`NotificationsV1`, func() {
 			Expect(notificationsService).To(BeNil())
 			Expect(serviceErr).ToNot(BeNil())
 		})
+		It(`Instantiate service client with error: Validation Error`, func() {
+			notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{})
+			Expect(notificationsService).To(BeNil())
+			Expect(serviceErr).ToNot(BeNil())
+		})
 	})
 	Describe(`Service constructor tests using external config`, func() {
+		accountID := "testString"
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
@@ -73,7 +83,9 @@ var _ = Describe(`NotificationsV1`, func() {
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{})
+				notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{
+					AccountID: core.StringPtr(accountID),
+				})
 				Expect(notificationsService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -87,7 +99,8 @@ var _ = Describe(`NotificationsV1`, func() {
 			It(`Create service client using external config and set url from constructor successfully`, func() {
 				SetTestEnvironment(testEnvironment)
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{
-					URL: "https://testService/api",
+					URL:       "https://testService/api",
+					AccountID: core.StringPtr(accountID),
 				})
 				Expect(notificationsService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
@@ -102,7 +115,9 @@ var _ = Describe(`NotificationsV1`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{})
+				notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{
+					AccountID: core.StringPtr(accountID),
+				})
 				err := notificationsService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -125,7 +140,9 @@ var _ = Describe(`NotificationsV1`, func() {
 			}
 
 			SetTestEnvironment(testEnvironment)
-			notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{})
+			notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{
+				AccountID: core.StringPtr(accountID),
+			})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(notificationsService).To(BeNil())
@@ -141,7 +158,8 @@ var _ = Describe(`NotificationsV1`, func() {
 
 			SetTestEnvironment(testEnvironment)
 			notificationsService, serviceErr := notificationsv1.NewNotificationsV1UsingExternalConfig(&notificationsv1.NotificationsV1Options{
-				URL: "{BAD_URL_STRING",
+				URL:       "{BAD_URL_STRING",
+				AccountID: core.StringPtr(accountID),
 			})
 
 			It(`Instantiate service client with error`, func() {
@@ -178,6 +196,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`ListAllChannels(listAllChannelsOptions *ListAllChannelsOptions) - Operation response error`, func() {
+		accountID := "testString"
 		listAllChannelsPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -200,13 +219,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the ListAllChannelsOptions model
 				listAllChannelsOptionsModel := new(notificationsv1.ListAllChannelsOptions)
-				listAllChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAllChannelsOptionsModel.Skip = core.Int64Ptr(int64(38))
@@ -230,6 +249,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`ListAllChannels(listAllChannelsOptions *ListAllChannelsOptions)`, func() {
+		accountID := "testString"
 		listAllChannelsPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -257,6 +277,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -264,7 +285,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the ListAllChannelsOptions model
 				listAllChannelsOptionsModel := new(notificationsv1.ListAllChannelsOptions)
-				listAllChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAllChannelsOptionsModel.Skip = core.Int64Ptr(int64(38))
@@ -318,6 +338,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -330,7 +351,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the ListAllChannelsOptions model
 				listAllChannelsOptionsModel := new(notificationsv1.ListAllChannelsOptions)
-				listAllChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAllChannelsOptionsModel.Skip = core.Int64Ptr(int64(38))
@@ -343,17 +363,17 @@ var _ = Describe(`NotificationsV1`, func() {
 				Expect(result).ToNot(BeNil())
 
 			})
-			It(`Invoke ListAllChannels with error: Operation validation and request error`, func() {
+			It(`Invoke ListAllChannels with error: Operation request error`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the ListAllChannelsOptions model
 				listAllChannelsOptionsModel := new(notificationsv1.ListAllChannelsOptions)
-				listAllChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAllChannelsOptionsModel.Skip = core.Int64Ptr(int64(38))
@@ -364,13 +384,6 @@ var _ = Describe(`NotificationsV1`, func() {
 				result, response, operationErr := notificationsService.ListAllChannels(listAllChannelsOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-				// Construct a second instance of the ListAllChannelsOptions model with no property values
-				listAllChannelsOptionsModelNew := new(notificationsv1.ListAllChannelsOptions)
-				// Invoke operation with invalid model (negative test)
-				result, response, operationErr = notificationsService.ListAllChannels(listAllChannelsOptionsModelNew)
-				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 			})
@@ -391,13 +404,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the ListAllChannelsOptions model
 				listAllChannelsOptionsModel := new(notificationsv1.ListAllChannelsOptions)
-				listAllChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAllChannelsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAllChannelsOptionsModel.Skip = core.Int64Ptr(int64(38))
@@ -417,6 +430,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`CreateNotificationChannel(createNotificationChannelOptions *CreateNotificationChannelOptions) - Operation response error`, func() {
+		accountID := "testString"
 		createNotificationChannelPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -437,6 +451,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -448,7 +463,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the CreateNotificationChannelOptions model
 				createNotificationChannelOptionsModel := new(notificationsv1.CreateNotificationChannelOptions)
-				createNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
 				createNotificationChannelOptionsModel.Endpoint = core.StringPtr("testString")
@@ -477,6 +491,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`CreateNotificationChannel(createNotificationChannelOptions *CreateNotificationChannelOptions)`, func() {
+		accountID := "testString"
 		createNotificationChannelPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -518,6 +533,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -530,7 +546,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the CreateNotificationChannelOptions model
 				createNotificationChannelOptionsModel := new(notificationsv1.CreateNotificationChannelOptions)
-				createNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
 				createNotificationChannelOptionsModel.Endpoint = core.StringPtr("testString")
@@ -603,6 +618,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -620,7 +636,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the CreateNotificationChannelOptions model
 				createNotificationChannelOptionsModel := new(notificationsv1.CreateNotificationChannelOptions)
-				createNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
 				createNotificationChannelOptionsModel.Endpoint = core.StringPtr("testString")
@@ -642,6 +657,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -653,7 +669,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the CreateNotificationChannelOptions model
 				createNotificationChannelOptionsModel := new(notificationsv1.CreateNotificationChannelOptions)
-				createNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
 				createNotificationChannelOptionsModel.Endpoint = core.StringPtr("testString")
@@ -696,6 +711,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -707,7 +723,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the CreateNotificationChannelOptions model
 				createNotificationChannelOptionsModel := new(notificationsv1.CreateNotificationChannelOptions)
-				createNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				createNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
 				createNotificationChannelOptionsModel.Endpoint = core.StringPtr("testString")
@@ -732,6 +747,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`DeleteNotificationChannels(deleteNotificationChannelsOptions *DeleteNotificationChannelsOptions) - Operation response error`, func() {
+		accountID := "testString"
 		deleteNotificationChannelsPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -752,13 +768,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelsOptions model
 				deleteNotificationChannelsOptionsModel := new(notificationsv1.DeleteNotificationChannelsOptions)
-				deleteNotificationChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Body = []string{"testString"}
 				deleteNotificationChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -781,6 +797,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`DeleteNotificationChannels(deleteNotificationChannelsOptions *DeleteNotificationChannelsOptions)`, func() {
+		accountID := "testString"
 		deleteNotificationChannelsPath := "/v1/testString/notifications/channels"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -822,6 +839,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -829,7 +847,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the DeleteNotificationChannelsOptions model
 				deleteNotificationChannelsOptionsModel := new(notificationsv1.DeleteNotificationChannelsOptions)
-				deleteNotificationChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Body = []string{"testString"}
 				deleteNotificationChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -896,6 +913,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -908,7 +926,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the DeleteNotificationChannelsOptions model
 				deleteNotificationChannelsOptionsModel := new(notificationsv1.DeleteNotificationChannelsOptions)
-				deleteNotificationChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Body = []string{"testString"}
 				deleteNotificationChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -924,13 +941,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelsOptions model
 				deleteNotificationChannelsOptionsModel := new(notificationsv1.DeleteNotificationChannelsOptions)
-				deleteNotificationChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Body = []string{"testString"}
 				deleteNotificationChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -967,13 +984,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelsOptions model
 				deleteNotificationChannelsOptionsModel := new(notificationsv1.DeleteNotificationChannelsOptions)
-				deleteNotificationChannelsOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Body = []string{"testString"}
 				deleteNotificationChannelsOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -992,6 +1009,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`DeleteNotificationChannel(deleteNotificationChannelOptions *DeleteNotificationChannelOptions) - Operation response error`, func() {
+		accountID := "testString"
 		deleteNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -1012,13 +1030,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelOptions model
 				deleteNotificationChannelOptionsModel := new(notificationsv1.DeleteNotificationChannelOptions)
-				deleteNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1041,6 +1059,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`DeleteNotificationChannel(deleteNotificationChannelOptions *DeleteNotificationChannelOptions)`, func() {
+		accountID := "testString"
 		deleteNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -1066,6 +1085,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1073,7 +1093,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the DeleteNotificationChannelOptions model
 				deleteNotificationChannelOptionsModel := new(notificationsv1.DeleteNotificationChannelOptions)
-				deleteNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1124,6 +1143,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1136,7 +1156,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the DeleteNotificationChannelOptions model
 				deleteNotificationChannelOptionsModel := new(notificationsv1.DeleteNotificationChannelOptions)
-				deleteNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1152,13 +1171,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelOptions model
 				deleteNotificationChannelOptionsModel := new(notificationsv1.DeleteNotificationChannelOptions)
-				deleteNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1195,13 +1214,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the DeleteNotificationChannelOptions model
 				deleteNotificationChannelOptionsModel := new(notificationsv1.DeleteNotificationChannelOptions)
-				deleteNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1220,6 +1239,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`GetNotificationChannel(getNotificationChannelOptions *GetNotificationChannelOptions) - Operation response error`, func() {
+		accountID := "testString"
 		getNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -1240,13 +1260,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetNotificationChannelOptions model
 				getNotificationChannelOptionsModel := new(notificationsv1.GetNotificationChannelOptions)
-				getNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1269,6 +1289,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`GetNotificationChannel(getNotificationChannelOptions *GetNotificationChannelOptions)`, func() {
+		accountID := "testString"
 		getNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -1294,6 +1315,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1301,7 +1323,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the GetNotificationChannelOptions model
 				getNotificationChannelOptionsModel := new(notificationsv1.GetNotificationChannelOptions)
-				getNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1352,6 +1373,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1364,7 +1386,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the GetNotificationChannelOptions model
 				getNotificationChannelOptionsModel := new(notificationsv1.GetNotificationChannelOptions)
-				getNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1380,13 +1401,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetNotificationChannelOptions model
 				getNotificationChannelOptionsModel := new(notificationsv1.GetNotificationChannelOptions)
-				getNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1423,13 +1444,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetNotificationChannelOptions model
 				getNotificationChannelOptionsModel := new(notificationsv1.GetNotificationChannelOptions)
-				getNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				getNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1448,6 +1469,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`UpdateNotificationChannel(updateNotificationChannelOptions *UpdateNotificationChannelOptions) - Operation response error`, func() {
+		accountID := "testString"
 		updateNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -1468,6 +1490,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1479,7 +1502,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
 				updateNotificationChannelOptionsModel := new(notificationsv1.UpdateNotificationChannelOptions)
-				updateNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
@@ -1509,6 +1531,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`UpdateNotificationChannel(updateNotificationChannelOptions *UpdateNotificationChannelOptions)`, func() {
+		accountID := "testString"
 		updateNotificationChannelPath := "/v1/testString/notifications/channels/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -1550,6 +1573,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1562,7 +1586,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
 				updateNotificationChannelOptionsModel := new(notificationsv1.UpdateNotificationChannelOptions)
-				updateNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
@@ -1636,6 +1659,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1653,7 +1677,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
 				updateNotificationChannelOptionsModel := new(notificationsv1.UpdateNotificationChannelOptions)
-				updateNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
@@ -1676,6 +1699,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1687,7 +1711,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
 				updateNotificationChannelOptionsModel := new(notificationsv1.UpdateNotificationChannelOptions)
-				updateNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
@@ -1731,6 +1754,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1742,7 +1766,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
 				updateNotificationChannelOptionsModel := new(notificationsv1.UpdateNotificationChannelOptions)
-				updateNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Name = core.StringPtr("testString")
 				updateNotificationChannelOptionsModel.Type = core.StringPtr("Webhook")
@@ -1768,6 +1791,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`TestNotificationChannel(testNotificationChannelOptions *TestNotificationChannelOptions) - Operation response error`, func() {
+		accountID := "testString"
 		testNotificationChannelPath := "/v1/testString/notifications/channels/testString/test"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -1788,13 +1812,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the TestNotificationChannelOptions model
 				testNotificationChannelOptionsModel := new(notificationsv1.TestNotificationChannelOptions)
-				testNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1817,6 +1841,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`TestNotificationChannel(testNotificationChannelOptions *TestNotificationChannelOptions)`, func() {
+		accountID := "testString"
 		testNotificationChannelPath := "/v1/testString/notifications/channels/testString/test"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -1842,6 +1867,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1849,7 +1875,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the TestNotificationChannelOptions model
 				testNotificationChannelOptionsModel := new(notificationsv1.TestNotificationChannelOptions)
-				testNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1900,6 +1925,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -1912,7 +1938,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the TestNotificationChannelOptions model
 				testNotificationChannelOptionsModel := new(notificationsv1.TestNotificationChannelOptions)
-				testNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1928,13 +1953,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the TestNotificationChannelOptions model
 				testNotificationChannelOptionsModel := new(notificationsv1.TestNotificationChannelOptions)
-				testNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1971,13 +1996,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the TestNotificationChannelOptions model
 				testNotificationChannelOptionsModel := new(notificationsv1.TestNotificationChannelOptions)
-				testNotificationChannelOptionsModel.AccountID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.ChannelID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.TransactionID = core.StringPtr("testString")
 				testNotificationChannelOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1996,6 +2021,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`GetPublicKey(getPublicKeyOptions *GetPublicKeyOptions) - Operation response error`, func() {
+		accountID := "testString"
 		getPublicKeyPath := "/v1/testString/notifications/public_key"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
@@ -2016,13 +2042,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetPublicKeyOptions model
 				getPublicKeyOptionsModel := new(notificationsv1.GetPublicKeyOptions)
-				getPublicKeyOptionsModel.AccountID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.TransactionID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -2044,6 +2070,7 @@ var _ = Describe(`NotificationsV1`, func() {
 		})
 	})
 	Describe(`GetPublicKey(getPublicKeyOptions *GetPublicKeyOptions)`, func() {
+		accountID := "testString"
 		getPublicKeyPath := "/v1/testString/notifications/public_key"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
@@ -2069,6 +2096,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -2076,7 +2104,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the GetPublicKeyOptions model
 				getPublicKeyOptionsModel := new(notificationsv1.GetPublicKeyOptions)
-				getPublicKeyOptionsModel.AccountID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.TransactionID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2126,6 +2153,7 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
@@ -2138,7 +2166,6 @@ var _ = Describe(`NotificationsV1`, func() {
 
 				// Construct an instance of the GetPublicKeyOptions model
 				getPublicKeyOptionsModel := new(notificationsv1.GetPublicKeyOptions)
-				getPublicKeyOptionsModel.AccountID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.TransactionID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2149,17 +2176,17 @@ var _ = Describe(`NotificationsV1`, func() {
 				Expect(result).ToNot(BeNil())
 
 			})
-			It(`Invoke GetPublicKey with error: Operation validation and request error`, func() {
+			It(`Invoke GetPublicKey with error: Operation request error`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetPublicKeyOptions model
 				getPublicKeyOptionsModel := new(notificationsv1.GetPublicKeyOptions)
-				getPublicKeyOptionsModel.AccountID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.TransactionID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -2168,13 +2195,6 @@ var _ = Describe(`NotificationsV1`, func() {
 				result, response, operationErr := notificationsService.GetPublicKey(getPublicKeyOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
-				Expect(response).To(BeNil())
-				Expect(result).To(BeNil())
-				// Construct a second instance of the GetPublicKeyOptions model with no property values
-				getPublicKeyOptionsModelNew := new(notificationsv1.GetPublicKeyOptions)
-				// Invoke operation with invalid model (negative test)
-				result, response, operationErr = notificationsService.GetPublicKey(getPublicKeyOptionsModelNew)
-				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 			})
@@ -2195,13 +2215,13 @@ var _ = Describe(`NotificationsV1`, func() {
 				notificationsService, serviceErr := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 					URL:           testServer.URL,
 					Authenticator: &core.NoAuthAuthenticator{},
+					AccountID:     core.StringPtr(accountID),
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(notificationsService).ToNot(BeNil())
 
 				// Construct an instance of the GetPublicKeyOptions model
 				getPublicKeyOptionsModel := new(notificationsv1.GetPublicKeyOptions)
-				getPublicKeyOptionsModel.AccountID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.TransactionID = core.StringPtr("testString")
 				getPublicKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2220,9 +2240,11 @@ var _ = Describe(`NotificationsV1`, func() {
 	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
+			accountID := "testString"
 			notificationsService, _ := notificationsv1.NewNotificationsV1(&notificationsv1.NotificationsV1Options{
 				URL:           "http://notificationsv1modelgenerator.com",
 				Authenticator: &core.NoAuthAuthenticator{},
+				AccountID:     core.StringPtr(accountID),
 			})
 			It(`Invoke NewCreateNotificationChannelOptions successfully`, func() {
 				// Construct an instance of the NotificationChannelAlertSourceItem model
@@ -2234,12 +2256,10 @@ var _ = Describe(`NotificationsV1`, func() {
 				Expect(notificationChannelAlertSourceItemModel.FindingTypes).To(Equal([]string{"testString"}))
 
 				// Construct an instance of the CreateNotificationChannelOptions model
-				accountID := "testString"
 				createNotificationChannelOptionsName := "testString"
 				createNotificationChannelOptionsType := "Webhook"
 				createNotificationChannelOptionsEndpoint := "testString"
-				createNotificationChannelOptionsModel := notificationsService.NewCreateNotificationChannelOptions(accountID, createNotificationChannelOptionsName, createNotificationChannelOptionsType, createNotificationChannelOptionsEndpoint)
-				createNotificationChannelOptionsModel.SetAccountID("testString")
+				createNotificationChannelOptionsModel := notificationsService.NewCreateNotificationChannelOptions(createNotificationChannelOptionsName, createNotificationChannelOptionsType, createNotificationChannelOptionsEndpoint)
 				createNotificationChannelOptionsModel.SetName("testString")
 				createNotificationChannelOptionsModel.SetType("Webhook")
 				createNotificationChannelOptionsModel.SetEndpoint("testString")
@@ -2250,7 +2270,6 @@ var _ = Describe(`NotificationsV1`, func() {
 				createNotificationChannelOptionsModel.SetTransactionID("testString")
 				createNotificationChannelOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createNotificationChannelOptionsModel).ToNot(BeNil())
-				Expect(createNotificationChannelOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(createNotificationChannelOptionsModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(createNotificationChannelOptionsModel.Type).To(Equal(core.StringPtr("Webhook")))
 				Expect(createNotificationChannelOptionsModel.Endpoint).To(Equal(core.StringPtr("testString")))
@@ -2263,72 +2282,57 @@ var _ = Describe(`NotificationsV1`, func() {
 			})
 			It(`Invoke NewDeleteNotificationChannelOptions successfully`, func() {
 				// Construct an instance of the DeleteNotificationChannelOptions model
-				accountID := "testString"
 				channelID := "testString"
-				deleteNotificationChannelOptionsModel := notificationsService.NewDeleteNotificationChannelOptions(accountID, channelID)
-				deleteNotificationChannelOptionsModel.SetAccountID("testString")
+				deleteNotificationChannelOptionsModel := notificationsService.NewDeleteNotificationChannelOptions(channelID)
 				deleteNotificationChannelOptionsModel.SetChannelID("testString")
 				deleteNotificationChannelOptionsModel.SetTransactionID("testString")
 				deleteNotificationChannelOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteNotificationChannelOptionsModel).ToNot(BeNil())
-				Expect(deleteNotificationChannelOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteNotificationChannelOptionsModel.ChannelID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteNotificationChannelOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteNotificationChannelOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewDeleteNotificationChannelsOptions successfully`, func() {
 				// Construct an instance of the DeleteNotificationChannelsOptions model
-				accountID := "testString"
 				body := []string{"testString"}
-				deleteNotificationChannelsOptionsModel := notificationsService.NewDeleteNotificationChannelsOptions(accountID, body)
-				deleteNotificationChannelsOptionsModel.SetAccountID("testString")
+				deleteNotificationChannelsOptionsModel := notificationsService.NewDeleteNotificationChannelsOptions(body)
 				deleteNotificationChannelsOptionsModel.SetBody([]string{"testString"})
 				deleteNotificationChannelsOptionsModel.SetTransactionID("testString")
 				deleteNotificationChannelsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteNotificationChannelsOptionsModel).ToNot(BeNil())
-				Expect(deleteNotificationChannelsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteNotificationChannelsOptionsModel.Body).To(Equal([]string{"testString"}))
 				Expect(deleteNotificationChannelsOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteNotificationChannelsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetNotificationChannelOptions successfully`, func() {
 				// Construct an instance of the GetNotificationChannelOptions model
-				accountID := "testString"
 				channelID := "testString"
-				getNotificationChannelOptionsModel := notificationsService.NewGetNotificationChannelOptions(accountID, channelID)
-				getNotificationChannelOptionsModel.SetAccountID("testString")
+				getNotificationChannelOptionsModel := notificationsService.NewGetNotificationChannelOptions(channelID)
 				getNotificationChannelOptionsModel.SetChannelID("testString")
 				getNotificationChannelOptionsModel.SetTransactionID("testString")
 				getNotificationChannelOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getNotificationChannelOptionsModel).ToNot(BeNil())
-				Expect(getNotificationChannelOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(getNotificationChannelOptionsModel.ChannelID).To(Equal(core.StringPtr("testString")))
 				Expect(getNotificationChannelOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(getNotificationChannelOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetPublicKeyOptions successfully`, func() {
 				// Construct an instance of the GetPublicKeyOptions model
-				accountID := "testString"
-				getPublicKeyOptionsModel := notificationsService.NewGetPublicKeyOptions(accountID)
-				getPublicKeyOptionsModel.SetAccountID("testString")
+				getPublicKeyOptionsModel := notificationsService.NewGetPublicKeyOptions()
 				getPublicKeyOptionsModel.SetTransactionID("testString")
 				getPublicKeyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getPublicKeyOptionsModel).ToNot(BeNil())
-				Expect(getPublicKeyOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(getPublicKeyOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(getPublicKeyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewListAllChannelsOptions successfully`, func() {
 				// Construct an instance of the ListAllChannelsOptions model
-				accountID := "testString"
-				listAllChannelsOptionsModel := notificationsService.NewListAllChannelsOptions(accountID)
-				listAllChannelsOptionsModel.SetAccountID("testString")
+				listAllChannelsOptionsModel := notificationsService.NewListAllChannelsOptions()
 				listAllChannelsOptionsModel.SetTransactionID("testString")
 				listAllChannelsOptionsModel.SetLimit(int64(38))
 				listAllChannelsOptionsModel.SetSkip(int64(38))
 				listAllChannelsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listAllChannelsOptionsModel).ToNot(BeNil())
-				Expect(listAllChannelsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(listAllChannelsOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(listAllChannelsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(38))))
 				Expect(listAllChannelsOptionsModel.Skip).To(Equal(core.Int64Ptr(int64(38))))
@@ -2342,15 +2346,12 @@ var _ = Describe(`NotificationsV1`, func() {
 			})
 			It(`Invoke NewTestNotificationChannelOptions successfully`, func() {
 				// Construct an instance of the TestNotificationChannelOptions model
-				accountID := "testString"
 				channelID := "testString"
-				testNotificationChannelOptionsModel := notificationsService.NewTestNotificationChannelOptions(accountID, channelID)
-				testNotificationChannelOptionsModel.SetAccountID("testString")
+				testNotificationChannelOptionsModel := notificationsService.NewTestNotificationChannelOptions(channelID)
 				testNotificationChannelOptionsModel.SetChannelID("testString")
 				testNotificationChannelOptionsModel.SetTransactionID("testString")
 				testNotificationChannelOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(testNotificationChannelOptionsModel).ToNot(BeNil())
-				Expect(testNotificationChannelOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(testNotificationChannelOptionsModel.ChannelID).To(Equal(core.StringPtr("testString")))
 				Expect(testNotificationChannelOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(testNotificationChannelOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -2365,13 +2366,11 @@ var _ = Describe(`NotificationsV1`, func() {
 				Expect(notificationChannelAlertSourceItemModel.FindingTypes).To(Equal([]string{"testString"}))
 
 				// Construct an instance of the UpdateNotificationChannelOptions model
-				accountID := "testString"
 				channelID := "testString"
 				updateNotificationChannelOptionsName := "testString"
 				updateNotificationChannelOptionsType := "Webhook"
 				updateNotificationChannelOptionsEndpoint := "testString"
-				updateNotificationChannelOptionsModel := notificationsService.NewUpdateNotificationChannelOptions(accountID, channelID, updateNotificationChannelOptionsName, updateNotificationChannelOptionsType, updateNotificationChannelOptionsEndpoint)
-				updateNotificationChannelOptionsModel.SetAccountID("testString")
+				updateNotificationChannelOptionsModel := notificationsService.NewUpdateNotificationChannelOptions(channelID, updateNotificationChannelOptionsName, updateNotificationChannelOptionsType, updateNotificationChannelOptionsEndpoint)
 				updateNotificationChannelOptionsModel.SetChannelID("testString")
 				updateNotificationChannelOptionsModel.SetName("testString")
 				updateNotificationChannelOptionsModel.SetType("Webhook")
@@ -2383,7 +2382,6 @@ var _ = Describe(`NotificationsV1`, func() {
 				updateNotificationChannelOptionsModel.SetTransactionID("testString")
 				updateNotificationChannelOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(updateNotificationChannelOptionsModel).ToNot(BeNil())
-				Expect(updateNotificationChannelOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(updateNotificationChannelOptionsModel.ChannelID).To(Equal(core.StringPtr("testString")))
 				Expect(updateNotificationChannelOptionsModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(updateNotificationChannelOptionsModel.Type).To(Equal(core.StringPtr("Webhook")))


### PR DESCRIPTION
fixed ITs to comply with the UX change, in both findings and notifications