### PR TITLE
Changed findings API url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The IBM Cloud Security & Compliance Center Go SDK allows developers to programma
 
 | Service Name                                                                         | Package name              |
 | ------------------------------------------------------------------------------------ | ------------------------- |
-| [Findings](https://cloud.ibm.com/apidocs/findings)                                   | findingsv1                |
+| [Findings](https://cloud.ibm.com/apidocs/security-compliance/findings)                                   | findingsv1                |
 | [Notifications](https://cloud.ibm.com/apidocs/security-compliance/si-notifications)  | notificationsv1           |
 | [Configuration Governance](https://cloud.ibm.com/apidocs/security-compliance/config) | configurationgovernancev1 |
 | [Admin Service](https://cloud.ibm.com/apidocs/security-compliance/admin)             | adminserviceapiv1         |


### PR DESCRIPTION
Findings API Docs Url : https://cloud.ibm.com/apidocs/security-compliance/findings