### PR TITLE
fix: Consolidating ProfilesID and ProfilesID into one entity

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: running integration tests
         env:
           SCC_ENV: ${{ secrets.SCC_ENV }}
-          SCC_IAM_PROFILE_ID: ${{ secrets.SCC_IAM_PROFILE_ID }}
+          SECURITY_AND_COMPLIANCE_CENTER_API_IAM_PROFILE_ID: ${{ secrets.SCC_IAM_PROFILE_ID }}
         run: build/testScript.sh
 
   release:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: running integration tests
         env:
           SCC_ENV: ${{ secrets.SCC_ENV }}
+          SCC_IAM_PROFILE_ID: ${{ secrets.SCC_IAM_PROFILE_ID }}
         run: build/testScript.sh
 
   release:

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -1754,7 +1754,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *deleteProfileAttachmentOptions.AttachmentID,
-		"profile_id":   *deleteProfileAttachmentOptions.ProfileID,
+		"profile_id":    *deleteProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -1823,7 +1823,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *getProfileAttachmentOptions.AttachmentID,
-		"profile_id":   *getProfileAttachmentOptions.ProfileID,
+		"profile_id":    *getProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -1892,7 +1892,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *replaceProfileAttachmentOptions.AttachmentID,
-		"profile_id":   *replaceProfileAttachmentOptions.ProfileID,
+		"profile_id":    *replaceProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
@@ -4981,7 +4981,7 @@ type CreateAttachmentOptions struct {
 // NewCreateAttachmentOptions : Instantiate CreateAttachmentOptions
 func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(profileID string, attachments []AttachmentsPrototype) *CreateAttachmentOptions {
 	return &CreateAttachmentOptions{
-		ProfileID:  core.StringPtr(profileID),
+		ProfileID:   core.StringPtr(profileID),
 		Attachments: attachments,
 	}
 }
@@ -5657,7 +5657,7 @@ type DeleteProfileAttachmentOptions struct {
 func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attachmentID string, profilesID string) *DeleteProfileAttachmentOptions {
 	return &DeleteProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:   core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profilesID),
 	}
 }
 
@@ -6240,7 +6240,7 @@ type GetProfileAttachmentOptions struct {
 func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachmentID string, profilesID string) *GetProfileAttachmentOptions {
 	return &GetProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:   core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profilesID),
 	}
 }
 
@@ -9253,7 +9253,7 @@ const (
 func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(attachmentID string, profilesID string) *ReplaceProfileAttachmentOptions {
 	return &ReplaceProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:   core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profilesID),
 	}
 }
 
@@ -9427,7 +9427,7 @@ const (
 // NewReplaceProfileOptions : Instantiate ReplaceProfileOptions
 func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profilesID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
 	return &ReplaceProfileOptions{
-		ProfileID:         core.StringPtr(profilesID),
+		ProfileID:          core.StringPtr(profilesID),
 		ProfileName:        core.StringPtr(profileName),
 		ProfileDescription: core.StringPtr(profileDescription),
 		ProfileType:        core.StringPtr(profileType),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -986,13 +986,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	}
 
 	pathParamsMap := map[string]string{
-		"profiles_id": *deleteCustomProfileOptions.ProfilesID,
+		"profile_id": *deleteCustomProfileOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1054,13 +1054,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 	}
 
 	pathParamsMap := map[string]string{
-		"profiles_id": *getProfileOptions.ProfilesID,
+		"profile_id": *getProfileOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1123,13 +1123,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 	}
 
 	pathParamsMap := map[string]string{
-		"profiles_id": *replaceProfileOptions.ProfilesID,
+		"profile_id": *replaceProfileOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1597,13 +1597,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListAtta
 	}
 
 	pathParamsMap := map[string]string{
-		"profiles_id": *listAttachmentsOptions.ProfilesID,
+		"profile_id": *listAttachmentsOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}/attachments`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1672,13 +1672,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateAt
 	}
 
 	pathParamsMap := map[string]string{
-		"profiles_id": *createAttachmentOptions.ProfilesID,
+		"profile_id": *createAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}/attachments`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1754,13 +1754,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *deleteProfileAttachmentOptions.AttachmentID,
-		"profiles_id":   *deleteProfileAttachmentOptions.ProfilesID,
+		"profile_id":   *deleteProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}/attachments/{attachment_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1823,13 +1823,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *getProfileAttachmentOptions.AttachmentID,
-		"profiles_id":   *getProfileAttachmentOptions.ProfilesID,
+		"profile_id":   *getProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}/attachments/{attachment_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1892,13 +1892,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 
 	pathParamsMap := map[string]string{
 		"attachment_id": *replaceProfileAttachmentOptions.AttachmentID,
-		"profiles_id":   *replaceProfileAttachmentOptions.ProfilesID,
+		"profile_id":   *replaceProfileAttachmentOptions.ProfileID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profiles_id}/attachments/{attachment_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -4959,13 +4959,10 @@ func UnmarshalControlsInControlLib(m map[string]json.RawMessage, result interfac
 // CreateAttachmentOptions : The CreateAttachment options.
 type CreateAttachmentOptions struct {
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The array that displays all of the available attachments.
 	Attachments []AttachmentsPrototype `json:"attachments" validate:"required"`
-
-	// The ID of the profile that is specified in the attachment.
-	ProfileID *string `json:"profile_id,omitempty"`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -4982,28 +4979,22 @@ type CreateAttachmentOptions struct {
 }
 
 // NewCreateAttachmentOptions : Instantiate CreateAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(profilesID string, attachments []AttachmentsPrototype) *CreateAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(profileID string, attachments []AttachmentsPrototype) *CreateAttachmentOptions {
 	return &CreateAttachmentOptions{
-		ProfilesID:  core.StringPtr(profilesID),
+		ProfileID:  core.StringPtr(profileID),
 		Attachments: attachments,
 	}
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *CreateAttachmentOptions) SetProfilesID(profilesID string) *CreateAttachmentOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *CreateAttachmentOptions) SetProfileID(profileID string) *CreateAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
 // SetAttachments : Allow user to set Attachments
 func (_options *CreateAttachmentOptions) SetAttachments(attachments []AttachmentsPrototype) *CreateAttachmentOptions {
 	_options.Attachments = attachments
-	return _options
-}
-
-// SetProfileID : Allow user to set ProfileID
-func (_options *CreateAttachmentOptions) SetProfileID(profileID string) *CreateAttachmentOptions {
-	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -5593,7 +5584,7 @@ func (options *DeleteCustomControlLibraryOptions) SetHeaders(param map[string]st
 // DeleteCustomProfileOptions : The DeleteCustomProfile options.
 type DeleteCustomProfileOptions struct {
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -5612,13 +5603,13 @@ type DeleteCustomProfileOptions struct {
 // NewDeleteCustomProfileOptions : Instantiate DeleteCustomProfileOptions
 func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(profilesID string) *DeleteCustomProfileOptions {
 	return &DeleteCustomProfileOptions{
-		ProfilesID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profilesID),
 	}
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *DeleteCustomProfileOptions) SetProfilesID(profilesID string) *DeleteCustomProfileOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *DeleteCustomProfileOptions) SetProfileID(profilesID string) *DeleteCustomProfileOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -5646,7 +5637,7 @@ type DeleteProfileAttachmentOptions struct {
 	AttachmentID *string `json:"attachment_id" validate:"required,ne="`
 
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -5666,7 +5657,7 @@ type DeleteProfileAttachmentOptions struct {
 func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attachmentID string, profilesID string) *DeleteProfileAttachmentOptions {
 	return &DeleteProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfilesID:   core.StringPtr(profilesID),
+		ProfileID:   core.StringPtr(profilesID),
 	}
 }
 
@@ -5676,9 +5667,9 @@ func (_options *DeleteProfileAttachmentOptions) SetAttachmentID(attachmentID str
 	return _options
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *DeleteProfileAttachmentOptions) SetProfilesID(profilesID string) *DeleteProfileAttachmentOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *DeleteProfileAttachmentOptions) SetProfileID(profilesID string) *DeleteProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -6229,7 +6220,7 @@ type GetProfileAttachmentOptions struct {
 	AttachmentID *string `json:"attachment_id" validate:"required,ne="`
 
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -6249,7 +6240,7 @@ type GetProfileAttachmentOptions struct {
 func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachmentID string, profilesID string) *GetProfileAttachmentOptions {
 	return &GetProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfilesID:   core.StringPtr(profilesID),
+		ProfileID:   core.StringPtr(profilesID),
 	}
 }
 
@@ -6259,9 +6250,9 @@ func (_options *GetProfileAttachmentOptions) SetAttachmentID(attachmentID string
 	return _options
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *GetProfileAttachmentOptions) SetProfilesID(profilesID string) *GetProfileAttachmentOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *GetProfileAttachmentOptions) SetProfileID(profilesID string) *GetProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -6286,7 +6277,7 @@ func (options *GetProfileAttachmentOptions) SetHeaders(param map[string]string) 
 // GetProfileOptions : The GetProfile options.
 type GetProfileOptions struct {
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -6305,13 +6296,13 @@ type GetProfileOptions struct {
 // NewGetProfileOptions : Instantiate GetProfileOptions
 func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(profilesID string) *GetProfileOptions {
 	return &GetProfileOptions{
-		ProfilesID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profilesID),
 	}
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *GetProfileOptions) SetProfilesID(profilesID string) *GetProfileOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *GetProfileOptions) SetProfileID(profilesID string) *GetProfileOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -7213,7 +7204,7 @@ func (options *ListAttachmentsAccountOptions) SetHeaders(param map[string]string
 // ListAttachmentsOptions : The ListAttachments options.
 type ListAttachmentsOptions struct {
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
@@ -7238,13 +7229,13 @@ type ListAttachmentsOptions struct {
 // NewListAttachmentsOptions : Instantiate ListAttachmentsOptions
 func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(profilesID string) *ListAttachmentsOptions {
 	return &ListAttachmentsOptions{
-		ProfilesID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profilesID),
 	}
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *ListAttachmentsOptions) SetProfilesID(profilesID string) *ListAttachmentsOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *ListAttachmentsOptions) SetProfileID(profilesID string) *ListAttachmentsOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -9179,13 +9170,10 @@ type ReplaceProfileAttachmentOptions struct {
 	AttachmentID *string `json:"attachment_id" validate:"required,ne="`
 
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The ID of the attachment.
 	ID *string `json:"id,omitempty"`
-
-	// The ID of the profile that is specified in the attachment.
-	ProfileID *string `json:"profile_id,omitempty"`
 
 	// The account ID that is associated to the attachment.
 	AccountID *string `json:"account_id,omitempty"`
@@ -9265,7 +9253,7 @@ const (
 func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(attachmentID string, profilesID string) *ReplaceProfileAttachmentOptions {
 	return &ReplaceProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfilesID:   core.StringPtr(profilesID),
+		ProfileID:   core.StringPtr(profilesID),
 	}
 }
 
@@ -9275,21 +9263,15 @@ func (_options *ReplaceProfileAttachmentOptions) SetAttachmentID(attachmentID st
 	return _options
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *ReplaceProfileAttachmentOptions) SetProfilesID(profilesID string) *ReplaceProfileAttachmentOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *ReplaceProfileAttachmentOptions) SetProfileID(profilesID string) *ReplaceProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
 // SetID : Allow user to set ID
 func (_options *ReplaceProfileAttachmentOptions) SetID(id string) *ReplaceProfileAttachmentOptions {
 	_options.ID = core.StringPtr(id)
-	return _options
-}
-
-// SetProfileID : Allow user to set ProfileID
-func (_options *ReplaceProfileAttachmentOptions) SetProfileID(profileID string) *ReplaceProfileAttachmentOptions {
-	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -9404,7 +9386,7 @@ func (options *ReplaceProfileAttachmentOptions) SetHeaders(param map[string]stri
 // ReplaceProfileOptions : The ReplaceProfile options.
 type ReplaceProfileOptions struct {
 	// The profile ID.
-	ProfilesID *string `json:"profiles_id" validate:"required,ne="`
+	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
 	// The name of the profile.
 	ProfileName *string `json:"profile_name" validate:"required"`
@@ -9445,7 +9427,7 @@ const (
 // NewReplaceProfileOptions : Instantiate ReplaceProfileOptions
 func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profilesID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
 	return &ReplaceProfileOptions{
-		ProfilesID:         core.StringPtr(profilesID),
+		ProfileID:         core.StringPtr(profilesID),
 		ProfileName:        core.StringPtr(profileName),
 		ProfileDescription: core.StringPtr(profileDescription),
 		ProfileType:        core.StringPtr(profileType),
@@ -9454,9 +9436,9 @@ func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profilesID str
 	}
 }
 
-// SetProfilesID : Allow user to set ProfilesID
-func (_options *ReplaceProfileOptions) SetProfilesID(profilesID string) *ReplaceProfileOptions {
-	_options.ProfilesID = core.StringPtr(profilesID)
+// SetProfileID : Allow user to set ProfileID
+func (_options *ReplaceProfileOptions) SetProfileID(profilesID string) *ReplaceProfileOptions {
+	_options.ProfileID = core.StringPtr(profilesID)
 	return _options
 }
 
@@ -11605,7 +11587,7 @@ func (pager *ControlLibrariesPager) GetAll() (allItems []ControlLibraryItem, err
 	return pager.GetAllWithContext(context.Background())
 }
 
-// ProfilesPager can be used to simplify the use of the "ListProfiles" method.
+// ProfilePager can be used to simplify the use of the "ListProfile" method.
 type ProfilesPager struct {
 	hasNext     bool
 	options     *ListProfilesOptions

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -5601,15 +5601,15 @@ type DeleteCustomProfileOptions struct {
 }
 
 // NewDeleteCustomProfileOptions : Instantiate DeleteCustomProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(profilesID string) *DeleteCustomProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(profileID string) *DeleteCustomProfileOptions {
 	return &DeleteCustomProfileOptions{
-		ProfileID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profileID),
 	}
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *DeleteCustomProfileOptions) SetProfileID(profilesID string) *DeleteCustomProfileOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *DeleteCustomProfileOptions) SetProfileID(profileID string) *DeleteCustomProfileOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -5654,10 +5654,10 @@ type DeleteProfileAttachmentOptions struct {
 }
 
 // NewDeleteProfileAttachmentOptions : Instantiate DeleteProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attachmentID string, profilesID string) *DeleteProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attachmentID string, profileID string) *DeleteProfileAttachmentOptions {
 	return &DeleteProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:    core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profileID),
 	}
 }
 
@@ -5668,8 +5668,8 @@ func (_options *DeleteProfileAttachmentOptions) SetAttachmentID(attachmentID str
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *DeleteProfileAttachmentOptions) SetProfileID(profilesID string) *DeleteProfileAttachmentOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *DeleteProfileAttachmentOptions) SetProfileID(profileID string) *DeleteProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -6237,10 +6237,10 @@ type GetProfileAttachmentOptions struct {
 }
 
 // NewGetProfileAttachmentOptions : Instantiate GetProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachmentID string, profilesID string) *GetProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachmentID string, profileID string) *GetProfileAttachmentOptions {
 	return &GetProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:    core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profileID),
 	}
 }
 
@@ -6251,8 +6251,8 @@ func (_options *GetProfileAttachmentOptions) SetAttachmentID(attachmentID string
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *GetProfileAttachmentOptions) SetProfileID(profilesID string) *GetProfileAttachmentOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *GetProfileAttachmentOptions) SetProfileID(profileID string) *GetProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -6294,15 +6294,15 @@ type GetProfileOptions struct {
 }
 
 // NewGetProfileOptions : Instantiate GetProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(profilesID string) *GetProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(profileID string) *GetProfileOptions {
 	return &GetProfileOptions{
-		ProfileID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profileID),
 	}
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *GetProfileOptions) SetProfileID(profilesID string) *GetProfileOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *GetProfileOptions) SetProfileID(profileID string) *GetProfileOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -7227,15 +7227,15 @@ type ListAttachmentsOptions struct {
 }
 
 // NewListAttachmentsOptions : Instantiate ListAttachmentsOptions
-func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(profilesID string) *ListAttachmentsOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(profileID string) *ListAttachmentsOptions {
 	return &ListAttachmentsOptions{
-		ProfileID: core.StringPtr(profilesID),
+		ProfileID: core.StringPtr(profileID),
 	}
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *ListAttachmentsOptions) SetProfileID(profilesID string) *ListAttachmentsOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *ListAttachmentsOptions) SetProfileID(profileID string) *ListAttachmentsOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -9250,10 +9250,10 @@ const (
 )
 
 // NewReplaceProfileAttachmentOptions : Instantiate ReplaceProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(attachmentID string, profilesID string) *ReplaceProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(attachmentID string, profileID string) *ReplaceProfileAttachmentOptions {
 	return &ReplaceProfileAttachmentOptions{
 		AttachmentID: core.StringPtr(attachmentID),
-		ProfileID:    core.StringPtr(profilesID),
+		ProfileID:    core.StringPtr(profileID),
 	}
 }
 
@@ -9264,8 +9264,8 @@ func (_options *ReplaceProfileAttachmentOptions) SetAttachmentID(attachmentID st
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *ReplaceProfileAttachmentOptions) SetProfileID(profilesID string) *ReplaceProfileAttachmentOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *ReplaceProfileAttachmentOptions) SetProfileID(profileID string) *ReplaceProfileAttachmentOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 
@@ -9425,9 +9425,9 @@ const (
 )
 
 // NewReplaceProfileOptions : Instantiate ReplaceProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profilesID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profileID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
 	return &ReplaceProfileOptions{
-		ProfileID:          core.StringPtr(profilesID),
+		ProfileID:          core.StringPtr(profileID),
 		ProfileName:        core.StringPtr(profileName),
 		ProfileDescription: core.StringPtr(profileDescription),
 		ProfileType:        core.StringPtr(profileType),
@@ -9437,8 +9437,8 @@ func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profilesID str
 }
 
 // SetProfileID : Allow user to set ProfileID
-func (_options *ReplaceProfileOptions) SetProfileID(profilesID string) *ReplaceProfileOptions {
-	_options.ProfileID = core.StringPtr(profilesID)
+func (_options *ReplaceProfileOptions) SetProfileID(profileID string) *ReplaceProfileOptions {
+	_options.ProfileID = core.StringPtr(profileID)
 	return _options
 }
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
@@ -826,7 +826,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListAttachments() result:")
 			// begin-list_attachments
 			listAttachmentsOptions := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-				ProfilesID:     &profileIdLink,
+				ProfileID:     &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
@@ -826,7 +826,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListAttachments() result:")
 			// begin-list_attachments
 			listAttachmentsOptions := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-				ProfileID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -141,7 +141,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			Expect(securityAndComplianceCenterApiService.Service.Options.URL).To(Equal(serviceURL))
 
 			core.SetLogger(core.NewLogger(core.LevelDebug, log.New(GinkgoWriter, "", log.LstdFlags), log.New(GinkgoWriter, "", log.LstdFlags)))
-			securityAndComplianceCenterApiService.EnableRetries(4, 30*time.Second)
+			securityAndComplianceCenterApiService.EnableRetries(3, 5*time.Second)
 		})
 	})
 
@@ -687,7 +687,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetProfile(getProfileOptions *GetProfileOptions)`, func() {
 			getProfileOptions := &securityandcompliancecenterapiv3.GetProfileOptions{
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}
@@ -719,7 +719,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			replaceProfileOptions := &securityandcompliancecenterapiv3.ReplaceProfileOptions{
-				ProfilesID:         &profileIdLink,
+				ProfileID:          &profileIdLink,
 				ProfileName:        core.StringPtr("test_profile1"),
 				ProfileDescription: core.StringPtr("test_description1"),
 				ProfileType:        core.StringPtr("custom"),
@@ -868,9 +868,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			createAttachmentOptions := &securityandcompliancecenterapiv3.CreateAttachmentOptions{
-				ProfilesID:     &profileIdLink,
-				Attachments:    []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel},
 				ProfileID:      &profileIdLink,
+				Attachments:    []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel},
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}
@@ -891,7 +890,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListAttachments(listAttachmentsOptions *ListAttachmentsOptions) with pagination`, func() {
 			listAttachmentsOptions := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),
@@ -920,7 +919,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListAttachments(listAttachmentsOptions *ListAttachmentsOptions) using AttachmentsPager`, func() {
 			listAttachmentsOptions := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),
@@ -960,7 +959,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		It(`GetProfileAttachment(getProfileAttachmentOptions *GetProfileAttachmentOptions)`, func() {
 			getProfileAttachmentOptions := &securityandcompliancecenterapiv3.GetProfileAttachmentOptions{
 				AttachmentID:   &attachmentIdLink,
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}
@@ -1018,9 +1017,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			replaceProfileAttachmentOptions := &securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions{
 				AttachmentID:         &attachmentIdLink,
-				ProfilesID:           &profileIdLink,
-				ID:                   core.StringPtr("testString"),
 				ProfileID:            &profileIdLink,
+				ID:                   core.StringPtr("testString"),
 				AccountID:            core.StringPtr(accountID),
 				InstanceID:           core.StringPtr(instanceID),
 				Scope:                []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel},
@@ -1624,7 +1622,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		It(`DeleteProfileAttachment(deleteProfileAttachmentOptions *DeleteProfileAttachmentOptions)`, func() {
 			deleteProfileAttachmentOptions := &securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions{
 				AttachmentID:   &attachmentIdLink,
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}
@@ -1642,7 +1640,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`DeleteCustomProfile(deleteCustomProfileOptions *DeleteCustomProfileOptions)`, func() {
 			deleteCustomProfileOptions := &securityandcompliancecenterapiv3.DeleteCustomProfileOptions{
-				ProfilesID:     &profileIdLink,
+				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -3597,7 +3597,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
-				deleteCustomProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3654,7 +3654,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
-				deleteCustomProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3719,7 +3719,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
-				deleteCustomProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3741,7 +3741,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
-				deleteCustomProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3784,7 +3784,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
-				deleteCustomProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3831,7 +3831,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
-				getProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3888,7 +3888,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
-				getProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3953,7 +3953,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
-				getProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -3975,7 +3975,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
-				getProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4018,7 +4018,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
-				getProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -4079,7 +4079,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
-				replaceProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				replaceProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -4171,7 +4171,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
-				replaceProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				replaceProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -4271,7 +4271,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
-				replaceProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				replaceProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -4312,7 +4312,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
-				replaceProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				replaceProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -4374,7 +4374,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
-				replaceProfileOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				replaceProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -5952,7 +5952,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
-				listAttachmentsOptionsModel.ProfilesID = core.StringPtr("testString")
+				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -6013,7 +6013,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
-				listAttachmentsOptionsModel.ProfilesID = core.StringPtr("testString")
+				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -6082,7 +6082,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
-				listAttachmentsOptionsModel.ProfilesID = core.StringPtr("testString")
+				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -6106,7 +6106,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
-				listAttachmentsOptionsModel.ProfilesID = core.StringPtr("testString")
+				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -6151,7 +6151,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
-				listAttachmentsOptionsModel.ProfilesID = core.StringPtr("testString")
+				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -6221,7 +6221,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-					ProfilesID:     core.StringPtr("testString"),
+					ProfileID:     core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -6249,7 +6249,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-					ProfilesID:     core.StringPtr("testString"),
+					ProfileID:     core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -6335,7 +6335,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
-				createAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6450,7 +6450,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
-				createAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6573,7 +6573,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
-				createAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6637,7 +6637,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
-				createAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6722,7 +6722,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
-				createAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6772,7 +6772,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				deleteProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6830,7 +6830,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				deleteProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6896,7 +6896,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				deleteProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6919,7 +6919,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				deleteProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6963,7 +6963,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				deleteProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7011,7 +7011,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				getProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7069,7 +7069,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				getProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7135,7 +7135,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				getProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7158,7 +7158,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				getProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7202,7 +7202,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				getProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XRequestID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -7285,7 +7285,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
@@ -7411,7 +7411,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
@@ -7545,7 +7545,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
@@ -7620,7 +7620,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
@@ -7716,7 +7716,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.ProfilesID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
@@ -13334,14 +13334,14 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				profilesID := "testString"
 				createAttachmentOptionsAttachments := []securityandcompliancecenterapiv3.AttachmentsPrototype{}
 				createAttachmentOptionsModel := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(profilesID, createAttachmentOptionsAttachments)
-				createAttachmentOptionsModel.SetProfilesID("testString")
+				createAttachmentOptionsModel.SetProfileID("testString")
 				createAttachmentOptionsModel.SetAttachments([]securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel})
 				createAttachmentOptionsModel.SetProfileID("testString")
 				createAttachmentOptionsModel.SetXCorrelationID("testString")
 				createAttachmentOptionsModel.SetXRequestID("testString")
 				createAttachmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createAttachmentOptionsModel).ToNot(BeNil())
-				Expect(createAttachmentOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(createAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(createAttachmentOptionsModel.Attachments).To(Equal([]securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}))
 				Expect(createAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(createAttachmentOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
@@ -13647,12 +13647,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the DeleteCustomProfileOptions model
 				profilesID := "testString"
 				deleteCustomProfileOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(profilesID)
-				deleteCustomProfileOptionsModel.SetProfilesID("testString")
+				deleteCustomProfileOptionsModel.SetProfileID("testString")
 				deleteCustomProfileOptionsModel.SetXCorrelationID("testString")
 				deleteCustomProfileOptionsModel.SetXRequestID("testString")
 				deleteCustomProfileOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteCustomProfileOptionsModel).ToNot(BeNil())
-				Expect(deleteCustomProfileOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteCustomProfileOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteCustomProfileOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteCustomProfileOptionsModel.XRequestID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteCustomProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -13663,13 +13663,13 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				profilesID := "testString"
 				deleteProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(attachmentID, profilesID)
 				deleteProfileAttachmentOptionsModel.SetAttachmentID("testString")
-				deleteProfileAttachmentOptionsModel.SetProfilesID("testString")
+				deleteProfileAttachmentOptionsModel.SetProfileID("testString")
 				deleteProfileAttachmentOptionsModel.SetXCorrelationID("testString")
 				deleteProfileAttachmentOptionsModel.SetXRequestID("testString")
 				deleteProfileAttachmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteProfileAttachmentOptionsModel).ToNot(BeNil())
 				Expect(deleteProfileAttachmentOptionsModel.AttachmentID).To(Equal(core.StringPtr("testString")))
-				Expect(deleteProfileAttachmentOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteProfileAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteProfileAttachmentOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteProfileAttachmentOptionsModel.XRequestID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteProfileAttachmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -13738,13 +13738,13 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				profilesID := "testString"
 				getProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(attachmentID, profilesID)
 				getProfileAttachmentOptionsModel.SetAttachmentID("testString")
-				getProfileAttachmentOptionsModel.SetProfilesID("testString")
+				getProfileAttachmentOptionsModel.SetProfileID("testString")
 				getProfileAttachmentOptionsModel.SetXCorrelationID("testString")
 				getProfileAttachmentOptionsModel.SetXRequestID("testString")
 				getProfileAttachmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getProfileAttachmentOptionsModel).ToNot(BeNil())
 				Expect(getProfileAttachmentOptionsModel.AttachmentID).To(Equal(core.StringPtr("testString")))
-				Expect(getProfileAttachmentOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(getProfileAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileAttachmentOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileAttachmentOptionsModel.XRequestID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileAttachmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -13753,12 +13753,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the GetProfileOptions model
 				profilesID := "testString"
 				getProfileOptionsModel := securityAndComplianceCenterApiService.NewGetProfileOptions(profilesID)
-				getProfileOptionsModel.SetProfilesID("testString")
+				getProfileOptionsModel.SetProfileID("testString")
 				getProfileOptionsModel.SetXCorrelationID("testString")
 				getProfileOptionsModel.SetXRequestID("testString")
 				getProfileOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getProfileOptionsModel).ToNot(BeNil())
-				Expect(getProfileOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(getProfileOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileOptionsModel.XRequestID).To(Equal(core.StringPtr("testString")))
 				Expect(getProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -13966,14 +13966,14 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				// Construct an instance of the ListAttachmentsOptions model
 				profilesID := "testString"
 				listAttachmentsOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsOptions(profilesID)
-				listAttachmentsOptionsModel.SetProfilesID("testString")
+				listAttachmentsOptionsModel.SetProfileID("testString")
 				listAttachmentsOptionsModel.SetXCorrelationID("testString")
 				listAttachmentsOptionsModel.SetXRequestID("testString")
 				listAttachmentsOptionsModel.SetLimit(int64(10))
 				listAttachmentsOptionsModel.SetStart("testString")
 				listAttachmentsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listAttachmentsOptionsModel).ToNot(BeNil())
-				Expect(listAttachmentsOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(listAttachmentsOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(listAttachmentsOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(listAttachmentsOptionsModel.XRequestID).To(Equal(core.StringPtr("testString")))
 				Expect(listAttachmentsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
@@ -14347,7 +14347,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				profilesID := "testString"
 				replaceProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(attachmentID, profilesID)
 				replaceProfileAttachmentOptionsModel.SetAttachmentID("testString")
-				replaceProfileAttachmentOptionsModel.SetProfilesID("testString")
+				replaceProfileAttachmentOptionsModel.SetProfileID("testString")
 				replaceProfileAttachmentOptionsModel.SetID("testString")
 				replaceProfileAttachmentOptionsModel.SetProfileID("testString")
 				replaceProfileAttachmentOptionsModel.SetAccountID("testString")
@@ -14370,7 +14370,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileAttachmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceProfileAttachmentOptionsModel).ToNot(BeNil())
 				Expect(replaceProfileAttachmentOptionsModel.AttachmentID).To(Equal(core.StringPtr("testString")))
-				Expect(replaceProfileAttachmentOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(replaceProfileAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceProfileAttachmentOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceProfileAttachmentOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceProfileAttachmentOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
@@ -14425,7 +14425,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileOptionsControls := []securityandcompliancecenterapiv3.ProfileControlsPrototype{}
 				replaceProfileOptionsDefaultParameters := []securityandcompliancecenterapiv3.DefaultParametersPrototype{}
 				replaceProfileOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileOptions(profilesID, replaceProfileOptionsProfileName, replaceProfileOptionsProfileDescription, replaceProfileOptionsProfileType, replaceProfileOptionsControls, replaceProfileOptionsDefaultParameters)
-				replaceProfileOptionsModel.SetProfilesID("testString")
+				replaceProfileOptionsModel.SetProfileID("testString")
 				replaceProfileOptionsModel.SetProfileName("test_profile1")
 				replaceProfileOptionsModel.SetProfileDescription("test_description1")
 				replaceProfileOptionsModel.SetProfileType("custom")
@@ -14435,7 +14435,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileOptionsModel.SetXRequestID("testString")
 				replaceProfileOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceProfileOptionsModel).ToNot(BeNil())
-				Expect(replaceProfileOptionsModel.ProfilesID).To(Equal(core.StringPtr("testString")))
+				Expect(replaceProfileOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceProfileOptionsModel.ProfileName).To(Equal(core.StringPtr("test_profile1")))
 				Expect(replaceProfileOptionsModel.ProfileDescription).To(Equal(core.StringPtr("test_description1")))
 				Expect(replaceProfileOptionsModel.ProfileType).To(Equal(core.StringPtr("custom")))

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -6221,7 +6221,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-					ProfileID:     core.StringPtr("testString"),
+					ProfileID:      core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -6249,7 +6249,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
-					ProfileID:     core.StringPtr("testString"),
+					ProfileID:      core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -13331,9 +13331,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(attachmentsPrototypeModel.AttachmentParameters).To(Equal([]securityandcompliancecenterapiv3.AttachmentParameterPrototype{*attachmentParameterPrototypeModel}))
 
 				// Construct an instance of the CreateAttachmentOptions model
-				profilesID := "testString"
+				profileID := "testString"
 				createAttachmentOptionsAttachments := []securityandcompliancecenterapiv3.AttachmentsPrototype{}
-				createAttachmentOptionsModel := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(profilesID, createAttachmentOptionsAttachments)
+				createAttachmentOptionsModel := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(profileID, createAttachmentOptionsAttachments)
 				createAttachmentOptionsModel.SetProfileID("testString")
 				createAttachmentOptionsModel.SetAttachments([]securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel})
 				createAttachmentOptionsModel.SetProfileID("testString")
@@ -13645,8 +13645,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteCustomProfileOptions successfully`, func() {
 				// Construct an instance of the DeleteCustomProfileOptions model
-				profilesID := "testString"
-				deleteCustomProfileOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(profilesID)
+				profileID := "testString"
+				deleteCustomProfileOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(profileID)
 				deleteCustomProfileOptionsModel.SetProfileID("testString")
 				deleteCustomProfileOptionsModel.SetXCorrelationID("testString")
 				deleteCustomProfileOptionsModel.SetXRequestID("testString")
@@ -13660,8 +13660,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			It(`Invoke NewDeleteProfileAttachmentOptions successfully`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				attachmentID := "testString"
-				profilesID := "testString"
-				deleteProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(attachmentID, profilesID)
+				profileID := "testString"
+				deleteProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(attachmentID, profileID)
 				deleteProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				deleteProfileAttachmentOptionsModel.SetProfileID("testString")
 				deleteProfileAttachmentOptionsModel.SetXCorrelationID("testString")
@@ -13735,8 +13735,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			It(`Invoke NewGetProfileAttachmentOptions successfully`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
 				attachmentID := "testString"
-				profilesID := "testString"
-				getProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(attachmentID, profilesID)
+				profileID := "testString"
+				getProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(attachmentID, profileID)
 				getProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				getProfileAttachmentOptionsModel.SetProfileID("testString")
 				getProfileAttachmentOptionsModel.SetXCorrelationID("testString")
@@ -13751,8 +13751,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetProfileOptions successfully`, func() {
 				// Construct an instance of the GetProfileOptions model
-				profilesID := "testString"
-				getProfileOptionsModel := securityAndComplianceCenterApiService.NewGetProfileOptions(profilesID)
+				profileID := "testString"
+				getProfileOptionsModel := securityAndComplianceCenterApiService.NewGetProfileOptions(profileID)
 				getProfileOptionsModel.SetProfileID("testString")
 				getProfileOptionsModel.SetXCorrelationID("testString")
 				getProfileOptionsModel.SetXRequestID("testString")
@@ -13964,8 +13964,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListAttachmentsOptions successfully`, func() {
 				// Construct an instance of the ListAttachmentsOptions model
-				profilesID := "testString"
-				listAttachmentsOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsOptions(profilesID)
+				profileID := "testString"
+				listAttachmentsOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsOptions(profileID)
 				listAttachmentsOptionsModel.SetProfileID("testString")
 				listAttachmentsOptionsModel.SetXCorrelationID("testString")
 				listAttachmentsOptionsModel.SetXRequestID("testString")
@@ -14344,8 +14344,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				attachmentID := "testString"
-				profilesID := "testString"
-				replaceProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(attachmentID, profilesID)
+				profileID := "testString"
+				replaceProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(attachmentID, profileID)
 				replaceProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				replaceProfileAttachmentOptionsModel.SetProfileID("testString")
 				replaceProfileAttachmentOptionsModel.SetID("testString")
@@ -14418,13 +14418,13 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(defaultParametersPrototypeModel.ParameterType).To(Equal(core.StringPtr("numeric")))
 
 				// Construct an instance of the ReplaceProfileOptions model
-				profilesID := "testString"
+				profileID := "testString"
 				replaceProfileOptionsProfileName := "test_profile1"
 				replaceProfileOptionsProfileDescription := "test_description1"
 				replaceProfileOptionsProfileType := "custom"
 				replaceProfileOptionsControls := []securityandcompliancecenterapiv3.ProfileControlsPrototype{}
 				replaceProfileOptionsDefaultParameters := []securityandcompliancecenterapiv3.DefaultParametersPrototype{}
-				replaceProfileOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileOptions(profilesID, replaceProfileOptionsProfileName, replaceProfileOptionsProfileDescription, replaceProfileOptionsProfileType, replaceProfileOptionsControls, replaceProfileOptionsDefaultParameters)
+				replaceProfileOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileOptions(profileID, replaceProfileOptionsProfileName, replaceProfileOptionsProfileDescription, replaceProfileOptionsProfileType, replaceProfileOptionsControls, replaceProfileOptionsDefaultParameters)
 				replaceProfileOptionsModel.SetProfileID("testString")
 				replaceProfileOptionsModel.SetProfileName("test_profile1")
 				replaceProfileOptionsModel.SetProfileDescription("test_description1")


### PR DESCRIPTION
## PR summary
Combining parameter `ProfilesID` and `ProfileID` into one object for the entity `ProfileAttachment`


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->