### PR TITLE
feat: adding the ability to specify `instance_id` to individual objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,17 @@ test-cov:
 test-int:
 	cd ${VDIR} && go test `go list ./...` -tags=integration
 
+test-int-verbose:
+	cd ${VDIR} && go test -v `go list ./...` -tags=integration
+
 test-int-cov:
 	cd ${VDIR} && go test `go list ./...` -tags=integration ${COVERAGE}
+
+test-examples:
+	cd ${VDIR} && go test -failfast `go list ./...` -tags=examples
+
+test-examples-verbose:
+	cd ${VDIR} && go test -v -failfast `go list ./...` -tags=examples
 
 lint:
 	diff -u <(echo -n) <(gofmt -d -s .)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Go client library to interact with various
     - [Go modules](#go-modules)
     - [`go get` command](#go-get-command)
   - [Using the SDK](#using-the-sdk)
+  - [Testing and Development](#testing-and-development)
   - [Questions](#questions)
   - [Issues](#issues)
   - [Open source @ IBM](#open-source--ibm)
@@ -83,6 +84,21 @@ Be sure to use the appropriate package name from the service table above for the
 ## Using the SDK
 For general SDK usage information, please see
 [this link](https://github.com/IBM/ibm-cloud-sdk-common/blob/main/README.md)
+
+## Testing and Development
+To test out any changes to SDK locally, `security_and_compliance_center_api_v3.env` should be in the base directory of the current version.
+
+```
+SECURITY_AND_COMPLIANCE_CENTER_API_URL=https://us-south.compliance.cloud.ibm.com
+SECURITY_AND_COMPLIANCE_CENTER_API_IAM_APIKEY_URL=https://iam.cloud.ibm.com/identity/token
+SECURITY_AND_COMPLIANCE_CENTER_API_IAM=<INSERT_SECRET_API_KEY>
+SECURITY_AND_COMPLIANCE_CENTER_API_SERVICENAME=SECURITY AND COMPLIANCE CENTER
+SECURITY_AND_COMPLIANCE_CENTER_API_ACCOUNTID=<INSERT_IBM_ACCOUNT_ID>
+SECURITY_AND_COMPLIANCE_CENTER_API_INSTANCEID=<INSERT_SCC_INSTANCE_ID>
+SECURITY_AND_COMPLIANCE_CENTER_API_ATTACHMENTID=<INSERT_SCC_PROFILE_ATTACHMENT_ID>
+SECURITY_AND_COMPLIANCE_CENTER_API_PROFILEID=<INSERT_SCC_PROFILE_ID
+SECURITY_AND_COMPLIANCE_CENTER_API_AUTHTYPE=noauth
+```
 
 ## Questions
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -5039,6 +5039,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(profileID st
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateAttachmentOptions) SetInstanceID(instanceID string) *CreateAttachmentOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetProfileID : Allow user to set ProfileID
 func (_options *CreateAttachmentOptions) SetProfileID(profileID string) *CreateAttachmentOptions {
 	_options.ProfileID = core.StringPtr(profileID)
@@ -5071,6 +5077,9 @@ func (options *CreateAttachmentOptions) SetHeaders(param map[string]string) *Cre
 
 // CreateCustomControlLibraryOptions : The CreateCustomControlLibrary options.
 type CreateCustomControlLibraryOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The control library name.
 	ControlLibraryName *string `json:"control_library_name" validate:"required"`
 
@@ -5107,9 +5116,6 @@ type CreateCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateCustomControlLibraryOptions.ControlLibraryType property.
@@ -5127,6 +5133,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateCustomControlLibraryOptions(co
 		ControlLibraryType:        core.StringPtr(controlLibraryType),
 		Controls:                  controls,
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateCustomControlLibraryOptions) SetInstanceID(instanceID string) *CreateCustomControlLibraryOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetControlLibraryName : Allow user to set ControlLibraryName
@@ -5197,6 +5209,9 @@ func (options *CreateCustomControlLibraryOptions) SetHeaders(param map[string]st
 
 // CreateProfileOptions : The CreateProfile options.
 type CreateProfileOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The name of the profile.
 	ProfileName *string `json:"profile_name" validate:"required"`
 
@@ -5224,9 +5239,6 @@ type CreateProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateProfileOptions.ProfileType property.
@@ -5245,6 +5257,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateProfileOptions(profileName str
 		Controls:           controls,
 		DefaultParameters:  defaultParameters,
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateProfileOptions) SetInstanceID(instanceID string) *CreateProfileOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProfileName : Allow user to set ProfileName
@@ -5328,6 +5346,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateProviderTypeInstanceOptions(pr
 	return &CreateProviderTypeInstanceOptions{
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateProviderTypeInstanceOptions) SetInstanceID(instanceID string) *CreateProviderTypeInstanceOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProviderTypeID : Allow user to set ProviderTypeID
@@ -5422,6 +5446,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateRuleOptions(description string
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateRuleOptions) SetInstanceID(instanceID string) *CreateRuleOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetDescription : Allow user to set Description
 func (_options *CreateRuleOptions) SetDescription(description string) *CreateRuleOptions {
 	_options.Description = core.StringPtr(description)
@@ -5509,6 +5539,12 @@ func (*SecurityAndComplianceCenterApiV3) NewCreateScanOptions(attachmentID strin
 	return &CreateScanOptions{
 		AttachmentID: core.StringPtr(attachmentID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *CreateScanOptions) SetInstanceID(instanceID string) *CreateScanOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetAttachmentID : Allow user to set AttachmentID
@@ -5601,6 +5637,9 @@ func UnmarshalDefaultParametersPrototype(m map[string]json.RawMessage, result in
 
 // DeleteCustomControlLibraryOptions : The DeleteCustomControlLibrary options.
 type DeleteCustomControlLibraryOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The control library ID.
 	ControlLibrariesID *string `json:"control_libraries_id" validate:"required,ne="`
 
@@ -5616,9 +5655,6 @@ type DeleteCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomControlLibraryOptions : Instantiate DeleteCustomControlLibraryOptions
@@ -5627,6 +5663,13 @@ func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomControlLibraryOptions(co
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
 }
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *DeleteCustomControlLibraryOptions) SetInstanceID(instanceID string) *DeleteCustomControlLibraryOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 
 // SetControlLibrariesID : Allow user to set ControlLibrariesID
 func (_options *DeleteCustomControlLibraryOptions) SetControlLibrariesID(controlLibrariesID string) *DeleteCustomControlLibraryOptions {
@@ -5654,6 +5697,9 @@ func (options *DeleteCustomControlLibraryOptions) SetHeaders(param map[string]st
 
 // DeleteCustomProfileOptions : The DeleteCustomProfile options.
 type DeleteCustomProfileOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The profile ID.
 	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
@@ -5669,9 +5715,6 @@ type DeleteCustomProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomProfileOptions : Instantiate DeleteCustomProfileOptions
@@ -5679,6 +5722,12 @@ func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(profileID
 	return &DeleteCustomProfileOptions{
 		ProfileID: core.StringPtr(profileID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *DeleteCustomProfileOptions) SetInstanceID(instanceID string) *DeleteCustomProfileOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProfileID : Allow user to set ProfileID
@@ -5737,6 +5786,13 @@ func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attac
 		ProfileID:    core.StringPtr(profileID),
 	}
 }
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *DeleteProfileAttachmentOptions) SetInstanceID(instanceID string) *DeleteProfileAttachmentOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 
 // SetAttachmentID : Allow user to set AttachmentID
 func (_options *DeleteProfileAttachmentOptions) SetAttachmentID(attachmentID string) *DeleteProfileAttachmentOptions {
@@ -5801,6 +5857,12 @@ func (*SecurityAndComplianceCenterApiV3) NewDeleteProviderTypeInstanceOptions(pr
 	}
 }
 
+// // SetInstanceID : Allow user to set InstanceID
+func (_options *DeleteProviderTypeInstanceOptions) SetInstanceID(instanceID string) *DeleteProviderTypeInstanceOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetProviderTypeID : Allow user to set ProviderTypeID
 func (_options *DeleteProviderTypeInstanceOptions) SetProviderTypeID(providerTypeID string) *DeleteProviderTypeInstanceOptions {
 	_options.ProviderTypeID = core.StringPtr(providerTypeID)
@@ -5858,6 +5920,12 @@ func (*SecurityAndComplianceCenterApiV3) NewDeleteRuleOptions(ruleID string) *De
 	return &DeleteRuleOptions{
 		RuleID: core.StringPtr(ruleID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *DeleteRuleOptions) SetInstanceID(instanceID string) *DeleteRuleOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetRuleID : Allow user to set RuleID
@@ -6200,6 +6268,9 @@ func UnmarshalFailedControls(m map[string]json.RawMessage, result interface{}) (
 
 // GetControlLibraryOptions : The GetControlLibrary options.
 type GetControlLibraryOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The control library ID.
 	ControlLibrariesID *string `json:"control_libraries_id" validate:"required,ne="`
 
@@ -6215,9 +6286,6 @@ type GetControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
@@ -6225,6 +6293,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetControlLibraryOptions(controlLibr
 	return &GetControlLibraryOptions{
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetControlLibraryOptions) SetInstanceID(instanceID string) *GetControlLibraryOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetControlLibrariesID : Allow user to set ControlLibrariesID
@@ -6277,6 +6351,12 @@ type GetLatestReportsOptions struct {
 // NewGetLatestReportsOptions : Instantiate GetLatestReportsOptions
 func (*SecurityAndComplianceCenterApiV3) NewGetLatestReportsOptions() *GetLatestReportsOptions {
 	return &GetLatestReportsOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetLatestReportsOptions) SetInstanceID(instanceID string) *GetLatestReportsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -6334,6 +6414,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachme
 		AttachmentID: core.StringPtr(attachmentID),
 		ProfileID:    core.StringPtr(profileID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetProfileAttachmentOptions) SetInstanceID(instanceID string) *GetProfileAttachmentOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetAttachmentID : Allow user to set AttachmentID
@@ -6395,6 +6481,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(profileID string) 
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetProfileOptions) SetInstanceID(instanceID string) *GetProfileOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetProfileID : Allow user to set ProfileID
 func (_options *GetProfileOptions) SetProfileID(profileID string) *GetProfileOptions {
 	_options.ProfileID = core.StringPtr(profileID)
@@ -6446,6 +6538,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeByIdOptions(providerT
 	return &GetProviderTypeByIdOptions{
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetProviderTypeByIdOptions) SetInstanceID(instanceID string) *GetProviderTypeByIdOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProviderTypeID : Allow user to set ProviderTypeID
@@ -6503,6 +6601,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeInstanceOptions(provi
 		ProviderTypeID:         core.StringPtr(providerTypeID),
 		ProviderTypeInstanceID: core.StringPtr(providerTypeInstanceID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetProviderTypeInstanceOptions) SetInstanceID(instanceID string) *GetProviderTypeInstanceOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProviderTypeID : Allow user to set ProviderTypeID
@@ -6640,6 +6744,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportControlsOptions(reportID st
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportControlsOptions) SetInstanceID(instanceID string) *GetReportControlsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetReportID : Allow user to set ReportID
 func (_options *GetReportControlsOptions) SetReportID(reportID string) *GetReportControlsOptions {
 	_options.ReportID = core.StringPtr(reportID)
@@ -6732,6 +6842,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportEvaluationOptions(reportID 
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportEvaluationOptions) SetInstanceID(instanceID string) *GetReportEvaluationOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetReportID : Allow user to set ReportID
 func (_options *GetReportEvaluationOptions) SetReportID(reportID string) *GetReportEvaluationOptions {
 	_options.ReportID = core.StringPtr(reportID)
@@ -6791,6 +6907,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportOptions(reportID string) *G
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportOptions) SetInstanceID(instanceID string) *GetReportOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetReportID : Allow user to set ReportID
 func (_options *GetReportOptions) SetReportID(reportID string) *GetReportOptions {
 	_options.ReportID = core.StringPtr(reportID)
@@ -6846,6 +6968,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportRuleOptions(reportID string
 		ReportID: core.StringPtr(reportID),
 		RuleID:   core.StringPtr(ruleID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportRuleOptions) SetInstanceID(instanceID string) *GetReportRuleOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetReportID : Allow user to set ReportID
@@ -6908,6 +7036,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportSummaryOptions(reportID str
 }
 
 // SetReportID : Allow user to set ReportID
+func (_options *GetReportSummaryOptions) SetInstanceID(instanceID string) *GetReportSummaryOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
+// SetReportID : Allow user to set ReportID
 func (_options *GetReportSummaryOptions) SetReportID(reportID string) *GetReportSummaryOptions {
 	_options.ReportID = core.StringPtr(reportID)
 	return _options
@@ -6958,6 +7092,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportTagsOptions(reportID string
 	return &GetReportTagsOptions{
 		ReportID: core.StringPtr(reportID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportTagsOptions) SetInstanceID(instanceID string) *GetReportTagsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetReportID : Allow user to set ReportID
@@ -7014,6 +7154,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetReportViolationsDriftOptions(repo
 	return &GetReportViolationsDriftOptions{
 		ReportID: core.StringPtr(reportID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetReportViolationsDriftOptions) SetInstanceID(instanceID string) *GetReportViolationsDriftOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetReportID : Allow user to set ReportID
@@ -7075,6 +7221,12 @@ func (*SecurityAndComplianceCenterApiV3) NewGetRuleOptions(ruleID string) *GetRu
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetRuleOptions) SetInstanceID(instanceID string) *GetRuleOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetRuleID : Allow user to set RuleID
 func (_options *GetRuleOptions) SetRuleID(ruleID string) *GetRuleOptions {
 	_options.RuleID = core.StringPtr(ruleID)
@@ -7101,6 +7253,9 @@ func (options *GetRuleOptions) SetHeaders(param map[string]string) *GetRuleOptio
 
 // GetSettingsOptions : The GetSettings options.
 type GetSettingsOptions struct {
+	// The ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request, and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7113,14 +7268,17 @@ type GetSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// The ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetSettingsOptions : Instantiate GetSettingsOptions
 func (*SecurityAndComplianceCenterApiV3) NewGetSettingsOptions() *GetSettingsOptions {
 	return &GetSettingsOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetSettingsOptions) SetInstanceID(instanceID string) *GetSettingsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -7367,6 +7525,12 @@ func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(profileID str
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListAttachmentsOptions) SetInstanceID(instanceID string) *ListAttachmentsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetProfileID : Allow user to set ProfileID
 func (_options *ListAttachmentsOptions) SetProfileID(profileID string) *ListAttachmentsOptions {
 	_options.ProfileID = core.StringPtr(profileID)
@@ -7405,6 +7569,9 @@ func (options *ListAttachmentsOptions) SetHeaders(param map[string]string) *List
 
 // ListControlLibrariesOptions : The ListControlLibraries options.
 type ListControlLibrariesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7426,14 +7593,17 @@ type ListControlLibrariesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListControlLibrariesOptions : Instantiate ListControlLibrariesOptions
 func (*SecurityAndComplianceCenterApiV3) NewListControlLibrariesOptions() *ListControlLibrariesOptions {
 	return &ListControlLibrariesOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListControlLibrariesOptions) SetInstanceID(instanceID string) *ListControlLibrariesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -7474,6 +7644,9 @@ func (options *ListControlLibrariesOptions) SetHeaders(param map[string]string) 
 
 // ListProfilesOptions : The ListProfiles options.
 type ListProfilesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request, and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests, and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7495,14 +7668,17 @@ type ListProfilesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListProfilesOptions : Instantiate ListProfilesOptions
 func (*SecurityAndComplianceCenterApiV3) NewListProfilesOptions() *ListProfilesOptions {
 	return &ListProfilesOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListProfilesOptions) SetInstanceID(instanceID string) *ListProfilesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -7618,6 +7794,12 @@ func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions() *ListProv
 	return &ListProviderTypesOptions{}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListProviderTypesOptions) SetInstanceID(instanceID string) *ListProviderTypesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetXCorrelationID : Allow user to set XCorrelationID
 func (_options *ListProviderTypesOptions) SetXCorrelationID(xCorrelationID string) *ListProviderTypesOptions {
 	_options.XCorrelationID = core.StringPtr(xCorrelationID)
@@ -7693,6 +7875,12 @@ func (*SecurityAndComplianceCenterApiV3) NewListReportEvaluationsOptions(reportI
 	return &ListReportEvaluationsOptions{
 		ReportID: core.StringPtr(reportID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListReportEvaluationsOptions) SetInstanceID(instanceID string) *ListReportEvaluationsOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetReportID : Allow user to set ReportID
@@ -7834,6 +8022,12 @@ func (*SecurityAndComplianceCenterApiV3) NewListReportResourcesOptions(reportID 
 	}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListReportResourcesOptions) SetInstanceID(instanceID string) *ListReportResourcesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetReportID : Allow user to set ReportID
 func (_options *ListReportResourcesOptions) SetReportID(reportID string) *ListReportResourcesOptions {
 	_options.ReportID = core.StringPtr(reportID)
@@ -7959,6 +8153,12 @@ func (*SecurityAndComplianceCenterApiV3) NewListReportsOptions() *ListReportsOpt
 	return &ListReportsOptions{}
 }
 
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListReportsOptions) SetInstanceID(instanceID string) *ListReportsOptions {
+	_options.XCorrelationID = core.StringPtr(instanceID)
+	return _options
+}
+
 // SetXCorrelationID : Allow user to set XCorrelationID
 func (_options *ListReportsOptions) SetXCorrelationID(xCorrelationID string) *ListReportsOptions {
 	_options.XCorrelationID = core.StringPtr(xCorrelationID)
@@ -8050,6 +8250,12 @@ type ListRulesOptions struct {
 // NewListRulesOptions : Instantiate ListRulesOptions
 func (*SecurityAndComplianceCenterApiV3) NewListRulesOptions() *ListRulesOptions {
 	return &ListRulesOptions{}
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (_options *ListRulesOptions) SetInstanceID(instanceID string) *ListRulesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -8368,6 +8574,9 @@ func UnmarshalParameterInfo(m map[string]json.RawMessage, result interface{}) (e
 
 // PostTestEventOptions : The PostTestEvent options.
 type PostTestEventOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request, and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -8380,14 +8589,17 @@ type PostTestEventOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewPostTestEventOptions : Instantiate PostTestEventOptions
 func (*SecurityAndComplianceCenterApiV3) NewPostTestEventOptions() *PostTestEventOptions {
 	return &PostTestEventOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *PostTestEventOptions) SetInstanceID(instanceID string) *PostTestEventOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -199,7 +199,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetSetti
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getSettingsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getSettingsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/settings`, nil)
 	if err != nil {
 		return
@@ -262,7 +265,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdateSe
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateSettingsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateSettingsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/settings`, nil)
 	if err != nil {
 		return
@@ -336,7 +342,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) PostTest
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *postTestEventOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *postTestEventOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/test_event`, nil)
 	if err != nil {
 		return
@@ -402,7 +411,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listControlLibrariesOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listControlLibrariesOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries`, nil)
 	if err != nil {
 		return
@@ -482,7 +494,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateCu
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createCustomControlLibraryOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createCustomControlLibraryOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries`, nil)
 	if err != nil {
 		return
@@ -585,7 +600,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomControlLibraryOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomControlLibraryOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -659,7 +677,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetContr
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getControlLibraryOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getControlLibraryOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -732,7 +753,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceC
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceCustomControlLibraryOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceCustomControlLibraryOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -846,7 +870,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProf
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProfilesOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProfilesOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles`, nil)
 	if err != nil {
 		return
@@ -921,7 +948,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProfileOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProfileOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles`, nil)
 	if err != nil {
 		return
@@ -1011,7 +1041,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomProfileOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomProfileOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1080,7 +1113,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1150,7 +1186,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1233,7 +1272,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRule
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listRulesOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listRulesOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/rules`, nil)
 	if err != nil {
 		return
@@ -1308,7 +1350,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateRu
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createRuleOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createRuleOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/rules`, nil)
 	if err != nil {
 		return
@@ -1404,7 +1449,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteRu
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteRuleOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteRuleOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1460,7 +1508,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRuleW
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getRuleOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getRuleOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1529,7 +1580,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceR
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceRuleOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceRuleOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1630,7 +1684,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListAtta
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
@@ -1706,7 +1763,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateAt
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createAttachmentOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createAttachmentOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
@@ -1789,7 +1849,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProfileAttachmentOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProfileAttachmentOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1859,7 +1922,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileAttachmentOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileAttachmentOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -1929,7 +1995,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileAttachmentOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileAttachmentOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -2050,7 +2119,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateSc
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createScanOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createScanOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/scans`, nil)
 	if err != nil {
 		return
@@ -2122,7 +2194,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListAtta
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsAccountOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsAccountOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/attachments`, nil)
 	if err != nil {
 		return
@@ -2189,7 +2264,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetLates
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getLatestReportsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getLatestReportsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/latest`, nil)
 	if err != nil {
 		return
@@ -2253,7 +2331,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports`, nil)
 	if err != nil {
 		return
@@ -2343,7 +2424,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -2411,7 +2495,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportSummaryOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportSummaryOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/summary`, pathParamsMap)
 	if err != nil {
 		return
@@ -2479,7 +2566,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportEvaluationOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportEvaluationOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/download`, pathParamsMap)
 	if err != nil {
 		return
@@ -2540,7 +2630,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportControlsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportControlsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/controls`, pathParamsMap)
 	if err != nil {
 		return
@@ -2628,7 +2721,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportRuleOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportRuleOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -2696,7 +2792,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportEvaluationsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportEvaluationsOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/evaluations`, pathParamsMap)
 	if err != nil {
 		return
@@ -2786,7 +2885,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportResourcesOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportResourcesOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/resources`, pathParamsMap)
 	if err != nil {
 		return
@@ -2879,7 +2981,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportTagsOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportTagsOptions.InstanceID)
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/tags`, pathParamsMap)
 	if err != nil {
 		return
@@ -2947,7 +3049,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportViolationsDriftOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportViolationsDriftOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/violations_drift`, pathParamsMap)
 	if err != nil {
 		return
@@ -3146,7 +3251,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProv
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProviderTypeInstancesOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProviderTypeInstancesOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
 	if err != nil {
 		return
@@ -3214,7 +3322,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProviderTypeInstanceOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProviderTypeInstanceOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
 	if err != nil {
 		return
@@ -3295,7 +3406,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProviderTypeInstanceOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProviderTypeInstanceOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -3353,7 +3467,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProviderTypeInstanceOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProviderTypeInstanceOptions.InstanceID)
+	if err != nil {
+		return
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -3421,7 +3538,9 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdatePr
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateProviderTypeInstanceOptions.InstanceID)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateProviderTypeInstanceOptions.InstanceID)
+	if err != nil {
+	}
 	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
@@ -5032,8 +5151,9 @@ type CreateAttachmentOptions struct {
 }
 
 // NewCreateAttachmentOptions : Instantiate CreateAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(profileID string, attachments []AttachmentsPrototype) *CreateAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateAttachmentOptions(instanceID string, profileID string, attachments []AttachmentsPrototype) *CreateAttachmentOptions {
 	return &CreateAttachmentOptions{
+		InstanceID:  core.StringPtr(instanceID),
 		ProfileID:   core.StringPtr(profileID),
 		Attachments: attachments,
 	}
@@ -5126,12 +5246,13 @@ const (
 )
 
 // NewCreateCustomControlLibraryOptions : Instantiate CreateCustomControlLibraryOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateCustomControlLibraryOptions(controlLibraryName string, controlLibraryDescription string, controlLibraryType string, controls []ControlsInControlLib) *CreateCustomControlLibraryOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateCustomControlLibraryOptions(instanceID string, controlLibraryName string, controlLibraryDescription string, controlLibraryType string, controls []ControlsInControlLib) *CreateCustomControlLibraryOptions {
 	return &CreateCustomControlLibraryOptions{
 		ControlLibraryName:        core.StringPtr(controlLibraryName),
 		ControlLibraryDescription: core.StringPtr(controlLibraryDescription),
 		ControlLibraryType:        core.StringPtr(controlLibraryType),
 		Controls:                  controls,
+		InstanceID:                core.StringPtr(instanceID),
 	}
 }
 
@@ -5249,11 +5370,12 @@ const (
 )
 
 // NewCreateProfileOptions : Instantiate CreateProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateProfileOptions(profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *CreateProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateProfileOptions(instanceID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *CreateProfileOptions {
 	return &CreateProfileOptions{
 		ProfileName:        core.StringPtr(profileName),
 		ProfileDescription: core.StringPtr(profileDescription),
 		ProfileType:        core.StringPtr(profileType),
+		InstanceID:         core.StringPtr(instanceID),
 		Controls:           controls,
 		DefaultParameters:  defaultParameters,
 	}
@@ -5342,8 +5464,9 @@ type CreateProviderTypeInstanceOptions struct {
 }
 
 // NewCreateProviderTypeInstanceOptions : Instantiate CreateProviderTypeInstanceOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateProviderTypeInstanceOptions(providerTypeID string) *CreateProviderTypeInstanceOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateProviderTypeInstanceOptions(instanceID string, providerTypeID string) *CreateProviderTypeInstanceOptions {
 	return &CreateProviderTypeInstanceOptions{
+		InstanceID:     core.StringPtr(instanceID),
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
 }
@@ -5438,8 +5561,9 @@ const (
 )
 
 // NewCreateRuleOptions : Instantiate CreateRuleOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateRuleOptions(description string, target *Target, requiredConfig RequiredConfigIntf) *CreateRuleOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateRuleOptions(instanceID string, description string, target *Target, requiredConfig RequiredConfigIntf) *CreateRuleOptions {
 	return &CreateRuleOptions{
+		InstanceID:     core.StringPtr(instanceID),
 		Description:    core.StringPtr(description),
 		Target:         target,
 		RequiredConfig: requiredConfig,
@@ -5535,8 +5659,9 @@ type CreateScanOptions struct {
 }
 
 // NewCreateScanOptions : Instantiate CreateScanOptions
-func (*SecurityAndComplianceCenterApiV3) NewCreateScanOptions(attachmentID string) *CreateScanOptions {
+func (*SecurityAndComplianceCenterApiV3) NewCreateScanOptions(instanceID string, attachmentID string) *CreateScanOptions {
 	return &CreateScanOptions{
+		InstanceID:   core.StringPtr(instanceID),
 		AttachmentID: core.StringPtr(attachmentID),
 	}
 }
@@ -5658,8 +5783,9 @@ type DeleteCustomControlLibraryOptions struct {
 }
 
 // NewDeleteCustomControlLibraryOptions : Instantiate DeleteCustomControlLibraryOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomControlLibraryOptions(controlLibrariesID string) *DeleteCustomControlLibraryOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomControlLibraryOptions(instanceID string, controlLibrariesID string) *DeleteCustomControlLibraryOptions {
 	return &DeleteCustomControlLibraryOptions{
+		InstanceID:         core.StringPtr(instanceID),
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
 }
@@ -5669,7 +5795,6 @@ func (_options *DeleteCustomControlLibraryOptions) SetInstanceID(instanceID stri
 	_options.InstanceID = core.StringPtr(instanceID)
 	return _options
 }
-
 
 // SetControlLibrariesID : Allow user to set ControlLibrariesID
 func (_options *DeleteCustomControlLibraryOptions) SetControlLibrariesID(controlLibrariesID string) *DeleteCustomControlLibraryOptions {
@@ -5718,9 +5843,10 @@ type DeleteCustomProfileOptions struct {
 }
 
 // NewDeleteCustomProfileOptions : Instantiate DeleteCustomProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(profileID string) *DeleteCustomProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteCustomProfileOptions(instanceID string, profileID string) *DeleteCustomProfileOptions {
 	return &DeleteCustomProfileOptions{
-		ProfileID: core.StringPtr(profileID),
+		InstanceID: core.StringPtr(instanceID),
+		ProfileID:  core.StringPtr(profileID),
 	}
 }
 
@@ -5780,8 +5906,9 @@ type DeleteProfileAttachmentOptions struct {
 }
 
 // NewDeleteProfileAttachmentOptions : Instantiate DeleteProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(attachmentID string, profileID string) *DeleteProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteProfileAttachmentOptions(instanceID string, attachmentID string, profileID string) *DeleteProfileAttachmentOptions {
 	return &DeleteProfileAttachmentOptions{
+		InstanceID:   core.StringPtr(instanceID),
 		AttachmentID: core.StringPtr(attachmentID),
 		ProfileID:    core.StringPtr(profileID),
 	}
@@ -5792,7 +5919,6 @@ func (_options *DeleteProfileAttachmentOptions) SetInstanceID(instanceID string)
 	_options.InstanceID = core.StringPtr(instanceID)
 	return _options
 }
-
 
 // SetAttachmentID : Allow user to set AttachmentID
 func (_options *DeleteProfileAttachmentOptions) SetAttachmentID(attachmentID string) *DeleteProfileAttachmentOptions {
@@ -5850,8 +5976,9 @@ type DeleteProviderTypeInstanceOptions struct {
 }
 
 // NewDeleteProviderTypeInstanceOptions : Instantiate DeleteProviderTypeInstanceOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteProviderTypeInstanceOptions(providerTypeID string, providerTypeInstanceID string) *DeleteProviderTypeInstanceOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteProviderTypeInstanceOptions(instanceID string, providerTypeID string, providerTypeInstanceID string) *DeleteProviderTypeInstanceOptions {
 	return &DeleteProviderTypeInstanceOptions{
+		InstanceID:             core.StringPtr(instanceID),
 		ProviderTypeID:         core.StringPtr(providerTypeID),
 		ProviderTypeInstanceID: core.StringPtr(providerTypeInstanceID),
 	}
@@ -5916,9 +6043,10 @@ type DeleteRuleOptions struct {
 }
 
 // NewDeleteRuleOptions : Instantiate DeleteRuleOptions
-func (*SecurityAndComplianceCenterApiV3) NewDeleteRuleOptions(ruleID string) *DeleteRuleOptions {
+func (*SecurityAndComplianceCenterApiV3) NewDeleteRuleOptions(instanceID string, ruleID string) *DeleteRuleOptions {
 	return &DeleteRuleOptions{
-		RuleID: core.StringPtr(ruleID),
+		InstanceID: core.StringPtr(instanceID),
+		RuleID:     core.StringPtr(ruleID),
 	}
 }
 
@@ -6289,7 +6417,7 @@ type GetControlLibraryOptions struct {
 }
 
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetControlLibraryOptions(controlLibrariesID string) *GetControlLibraryOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetControlLibraryOptions(instanceID string, controlLibrariesID string) *GetControlLibraryOptions {
 	return &GetControlLibraryOptions{
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
@@ -6349,8 +6477,10 @@ type GetLatestReportsOptions struct {
 }
 
 // NewGetLatestReportsOptions : Instantiate GetLatestReportsOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetLatestReportsOptions() *GetLatestReportsOptions {
-	return &GetLatestReportsOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewGetLatestReportsOptions(instanceID string) *GetLatestReportsOptions {
+	return &GetLatestReportsOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
@@ -6409,8 +6539,9 @@ type GetProfileAttachmentOptions struct {
 }
 
 // NewGetProfileAttachmentOptions : Instantiate GetProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(attachmentID string, profileID string) *GetProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProfileAttachmentOptions(instanceID string, attachmentID string, profileID string) *GetProfileAttachmentOptions {
 	return &GetProfileAttachmentOptions{
+		InstanceID:   core.StringPtr(instanceID),
 		AttachmentID: core.StringPtr(attachmentID),
 		ProfileID:    core.StringPtr(profileID),
 	}
@@ -6475,9 +6606,10 @@ type GetProfileOptions struct {
 }
 
 // NewGetProfileOptions : Instantiate GetProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(profileID string) *GetProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProfileOptions(instanceID string, profileID string) *GetProfileOptions {
 	return &GetProfileOptions{
-		ProfileID: core.StringPtr(profileID),
+		InstanceID: core.StringPtr(instanceID),
+		ProfileID:  core.StringPtr(profileID),
 	}
 }
 
@@ -6513,9 +6645,6 @@ func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfil
 
 // GetProviderTypeByIdOptions : The GetProviderTypeByID options.
 type GetProviderTypeByIdOptions struct {
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
-
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -6538,12 +6667,6 @@ func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeByIdOptions(providerT
 	return &GetProviderTypeByIdOptions{
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
-}
-
-// SetInstanceID : Allow user to set InstanceID
-func (_options *GetProviderTypeByIdOptions) SetInstanceID(instanceID string) *GetProviderTypeByIdOptions {
-	_options.InstanceID = core.StringPtr(instanceID)
-	return _options
 }
 
 // SetProviderTypeID : Allow user to set ProviderTypeID
@@ -6596,8 +6719,9 @@ type GetProviderTypeInstanceOptions struct {
 }
 
 // NewGetProviderTypeInstanceOptions : Instantiate GetProviderTypeInstanceOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeInstanceOptions(providerTypeID string, providerTypeInstanceID string) *GetProviderTypeInstanceOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeInstanceOptions(instanceID string, providerTypeID string, providerTypeInstanceID string) *GetProviderTypeInstanceOptions {
 	return &GetProviderTypeInstanceOptions{
+		InstanceID:             core.StringPtr(instanceID),
 		ProviderTypeID:         core.StringPtr(providerTypeID),
 		ProviderTypeInstanceID: core.StringPtr(providerTypeInstanceID),
 	}
@@ -6738,9 +6862,10 @@ const (
 )
 
 // NewGetReportControlsOptions : Instantiate GetReportControlsOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportControlsOptions(reportID string) *GetReportControlsOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportControlsOptions(instanceID string, reportID string) *GetReportControlsOptions {
 	return &GetReportControlsOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -6836,9 +6961,10 @@ type GetReportEvaluationOptions struct {
 }
 
 // NewGetReportEvaluationOptions : Instantiate GetReportEvaluationOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportEvaluationOptions(reportID string) *GetReportEvaluationOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportEvaluationOptions(instanceID string, reportID string) *GetReportEvaluationOptions {
 	return &GetReportEvaluationOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -6901,9 +7027,10 @@ type GetReportOptions struct {
 }
 
 // NewGetReportOptions : Instantiate GetReportOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportOptions(reportID string) *GetReportOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportOptions(instanceID string, reportID string) *GetReportOptions {
 	return &GetReportOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -6963,10 +7090,11 @@ type GetReportRuleOptions struct {
 }
 
 // NewGetReportRuleOptions : Instantiate GetReportRuleOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportRuleOptions(reportID string, ruleID string) *GetReportRuleOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportRuleOptions(instanceID string, reportID string, ruleID string) *GetReportRuleOptions {
 	return &GetReportRuleOptions{
-		ReportID: core.StringPtr(reportID),
-		RuleID:   core.StringPtr(ruleID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
+		RuleID:     core.StringPtr(ruleID),
 	}
 }
 
@@ -7029,13 +7157,14 @@ type GetReportSummaryOptions struct {
 }
 
 // NewGetReportSummaryOptions : Instantiate GetReportSummaryOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportSummaryOptions(reportID string) *GetReportSummaryOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportSummaryOptions(instanceID string, reportID string) *GetReportSummaryOptions {
 	return &GetReportSummaryOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
-// SetReportID : Allow user to set ReportID
+// SetInstanceID : Allow user to set InstanceID
 func (_options *GetReportSummaryOptions) SetInstanceID(instanceID string) *GetReportSummaryOptions {
 	_options.InstanceID = core.StringPtr(instanceID)
 	return _options
@@ -7088,9 +7217,10 @@ type GetReportTagsOptions struct {
 }
 
 // NewGetReportTagsOptions : Instantiate GetReportTagsOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportTagsOptions(reportID string) *GetReportTagsOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportTagsOptions(instanceID string, reportID string) *GetReportTagsOptions {
 	return &GetReportTagsOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -7150,9 +7280,10 @@ type GetReportViolationsDriftOptions struct {
 }
 
 // NewGetReportViolationsDriftOptions : Instantiate GetReportViolationsDriftOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetReportViolationsDriftOptions(reportID string) *GetReportViolationsDriftOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetReportViolationsDriftOptions(instanceID string, reportID string) *GetReportViolationsDriftOptions {
 	return &GetReportViolationsDriftOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -7215,9 +7346,10 @@ type GetRuleOptions struct {
 }
 
 // NewGetRuleOptions : Instantiate GetRuleOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetRuleOptions(ruleID string) *GetRuleOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetRuleOptions(instanceID string, ruleID string) *GetRuleOptions {
 	return &GetRuleOptions{
-		RuleID: core.StringPtr(ruleID),
+		InstanceID: core.StringPtr(instanceID),
+		RuleID:     core.StringPtr(ruleID),
 	}
 }
 
@@ -7271,8 +7403,10 @@ type GetSettingsOptions struct {
 }
 
 // NewGetSettingsOptions : Instantiate GetSettingsOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetSettingsOptions() *GetSettingsOptions {
-	return &GetSettingsOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewGetSettingsOptions(instanceID string) *GetSettingsOptions {
+	return &GetSettingsOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
@@ -7456,8 +7590,10 @@ type ListAttachmentsAccountOptions struct {
 }
 
 // NewListAttachmentsAccountOptions : Instantiate ListAttachmentsAccountOptions
-func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsAccountOptions() *ListAttachmentsAccountOptions {
-	return &ListAttachmentsAccountOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsAccountOptions(instanceID string) *ListAttachmentsAccountOptions {
+	return &ListAttachmentsAccountOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -7596,8 +7732,10 @@ type ListControlLibrariesOptions struct {
 }
 
 // NewListControlLibrariesOptions : Instantiate ListControlLibrariesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListControlLibrariesOptions() *ListControlLibrariesOptions {
-	return &ListControlLibrariesOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewListControlLibrariesOptions(instanceID string) *ListControlLibrariesOptions {
+	return &ListControlLibrariesOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
@@ -7671,8 +7809,10 @@ type ListProfilesOptions struct {
 }
 
 // NewListProfilesOptions : Instantiate ListProfilesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListProfilesOptions() *ListProfilesOptions {
-	return &ListProfilesOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewListProfilesOptions(instanceID string) *ListProfilesOptions {
+	return &ListProfilesOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
@@ -7740,8 +7880,9 @@ type ListProviderTypeInstancesOptions struct {
 }
 
 // NewListProviderTypeInstancesOptions : Instantiate ListProviderTypeInstancesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListProviderTypeInstancesOptions(providerTypeID string) *ListProviderTypeInstancesOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListProviderTypeInstancesOptions(instanceID string, providerTypeID string) *ListProviderTypeInstancesOptions {
 	return &ListProviderTypeInstancesOptions{
+		InstanceID:     core.StringPtr(instanceID),
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
 }
@@ -7772,9 +7913,6 @@ func (options *ListProviderTypeInstancesOptions) SetHeaders(param map[string]str
 
 // ListProviderTypesOptions : The ListProviderTypes options.
 type ListProviderTypesOptions struct {
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
-
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7790,14 +7928,8 @@ type ListProviderTypesOptions struct {
 }
 
 // NewListProviderTypesOptions : Instantiate ListProviderTypesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions() *ListProviderTypesOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions(instanceID string) *ListProviderTypesOptions {
 	return &ListProviderTypesOptions{}
-}
-
-// SetInstanceID : Allow user to set InstanceID
-func (_options *ListProviderTypesOptions) SetInstanceID(instanceID string) *ListProviderTypesOptions {
-	_options.InstanceID = core.StringPtr(instanceID)
-	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID
@@ -7871,9 +8003,10 @@ const (
 )
 
 // NewListReportEvaluationsOptions : Instantiate ListReportEvaluationsOptions
-func (*SecurityAndComplianceCenterApiV3) NewListReportEvaluationsOptions(reportID string) *ListReportEvaluationsOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListReportEvaluationsOptions(instanceID string, reportID string) *ListReportEvaluationsOptions {
 	return &ListReportEvaluationsOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -8016,9 +8149,10 @@ const (
 )
 
 // NewListReportResourcesOptions : Instantiate ListReportResourcesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListReportResourcesOptions(reportID string) *ListReportResourcesOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListReportResourcesOptions(instanceID string, reportID string) *ListReportResourcesOptions {
 	return &ListReportResourcesOptions{
-		ReportID: core.StringPtr(reportID),
+		InstanceID: core.StringPtr(instanceID),
+		ReportID:   core.StringPtr(reportID),
 	}
 }
 
@@ -8149,13 +8283,15 @@ const (
 )
 
 // NewListReportsOptions : Instantiate ListReportsOptions
-func (*SecurityAndComplianceCenterApiV3) NewListReportsOptions() *ListReportsOptions {
-	return &ListReportsOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewListReportsOptions(instanceID string) *ListReportsOptions {
+	return &ListReportsOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
 func (_options *ListReportsOptions) SetInstanceID(instanceID string) *ListReportsOptions {
-	_options.XCorrelationID = core.StringPtr(instanceID)
+	_options.InstanceID = core.StringPtr(instanceID)
 	return _options
 }
 
@@ -8252,7 +8388,7 @@ func (*SecurityAndComplianceCenterApiV3) NewListRulesOptions() *ListRulesOptions
 	return &ListRulesOptions{}
 }
 
-// SetXCorrelationID : Allow user to set XCorrelationID
+// SetInstanceID : Allow user to set InstanceID
 func (_options *ListRulesOptions) SetInstanceID(instanceID string) *ListRulesOptions {
 	_options.InstanceID = core.StringPtr(instanceID)
 	return _options
@@ -8592,8 +8728,10 @@ type PostTestEventOptions struct {
 }
 
 // NewPostTestEventOptions : Instantiate PostTestEventOptions
-func (*SecurityAndComplianceCenterApiV3) NewPostTestEventOptions() *PostTestEventOptions {
-	return &PostTestEventOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewPostTestEventOptions(instanceID string) *PostTestEventOptions {
+	return &PostTestEventOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID
@@ -9414,8 +9552,9 @@ const (
 )
 
 // NewReplaceCustomControlLibraryOptions : Instantiate ReplaceCustomControlLibraryOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceCustomControlLibraryOptions(controlLibrariesID string) *ReplaceCustomControlLibraryOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceCustomControlLibraryOptions(instanceID string, controlLibrariesID string) *ReplaceCustomControlLibraryOptions {
 	return &ReplaceCustomControlLibraryOptions{
+		InstanceID:         core.StringPtr(instanceID),
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
 }
@@ -9626,8 +9765,9 @@ const (
 )
 
 // NewReplaceProfileAttachmentOptions : Instantiate ReplaceProfileAttachmentOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(attachmentID string, profileID string) *ReplaceProfileAttachmentOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileAttachmentOptions(instanceID string, attachmentID string, profileID string) *ReplaceProfileAttachmentOptions {
 	return &ReplaceProfileAttachmentOptions{
+		InstanceID:   core.StringPtr(instanceID),
 		AttachmentID: core.StringPtr(attachmentID),
 		ProfileID:    core.StringPtr(profileID),
 	}
@@ -9804,8 +9944,9 @@ const (
 )
 
 // NewReplaceProfileOptions : Instantiate ReplaceProfileOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(profileID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceProfileOptions(instanceID string, profileID string, profileName string, profileDescription string, profileType string, controls []ProfileControlsPrototype, defaultParameters []DefaultParametersPrototype) *ReplaceProfileOptions {
 	return &ReplaceProfileOptions{
+		InstanceID:         core.StringPtr(instanceID),
 		ProfileID:          core.StringPtr(profileID),
 		ProfileName:        core.StringPtr(profileName),
 		ProfileDescription: core.StringPtr(profileDescription),
@@ -9926,8 +10067,9 @@ const (
 )
 
 // NewReplaceRuleOptions : Instantiate ReplaceRuleOptions
-func (*SecurityAndComplianceCenterApiV3) NewReplaceRuleOptions(ruleID string, ifMatch string, description string, target *Target, requiredConfig RequiredConfigIntf) *ReplaceRuleOptions {
+func (*SecurityAndComplianceCenterApiV3) NewReplaceRuleOptions(instanceID string, ruleID string, ifMatch string, description string, target *Target, requiredConfig RequiredConfigIntf) *ReplaceRuleOptions {
 	return &ReplaceRuleOptions{
+		InstanceID:     core.StringPtr(instanceID),
 		RuleID:         core.StringPtr(ruleID),
 		IfMatch:        core.StringPtr(ifMatch),
 		Description:    core.StringPtr(description),
@@ -11509,8 +11651,9 @@ type UpdateProviderTypeInstanceOptions struct {
 }
 
 // NewUpdateProviderTypeInstanceOptions : Instantiate UpdateProviderTypeInstanceOptions
-func (*SecurityAndComplianceCenterApiV3) NewUpdateProviderTypeInstanceOptions(providerTypeID string, providerTypeInstanceID string) *UpdateProviderTypeInstanceOptions {
+func (*SecurityAndComplianceCenterApiV3) NewUpdateProviderTypeInstanceOptions(instanceID string, providerTypeID string, providerTypeInstanceID string) *UpdateProviderTypeInstanceOptions {
 	return &UpdateProviderTypeInstanceOptions{
+		InstanceID:             core.StringPtr(instanceID),
 		ProviderTypeID:         core.StringPtr(providerTypeID),
 		ProviderTypeInstanceID: core.StringPtr(providerTypeInstanceID),
 	}
@@ -11560,6 +11703,9 @@ func (options *UpdateProviderTypeInstanceOptions) SetHeaders(param map[string]st
 
 // UpdateSettingsOptions : The UpdateSettings options.
 type UpdateSettingsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The Event Notifications settings.
 	EventNotifications *EventNotifications `json:"event_notifications,omitempty"`
 
@@ -11578,14 +11724,13 @@ type UpdateSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewUpdateSettingsOptions : Instantiate UpdateSettingsOptions
-func (*SecurityAndComplianceCenterApiV3) NewUpdateSettingsOptions() *UpdateSettingsOptions {
-	return &UpdateSettingsOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewUpdateSettingsOptions(instanceID string) *UpdateSettingsOptions {
+	return &UpdateSettingsOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetEventNotifications : Allow user to set EventNotifications
@@ -12468,6 +12613,9 @@ func (pager *ReportResourcesPager) GetAll() (allItems []Resource, err error) {
 }
 
 // getInstanceBasedURL uses the baseURL and instanceID to return the correct endpoint URL
-func getInstanceBasedURL(baseURL, instanceID string) string {
-	return baseURL + "/instances/" + instanceID + "/v3"
+func getInstanceBasedURL(baseURL, instanceID string) (string, error) {
+	if baseURL == "" {
+		return "", fmt.Errorf("service URL is empty")
+	}
+	return fmt.Sprintf("%s/instances/%s/v3", baseURL, instanceID), nil
 }

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -7673,7 +7673,7 @@ type ListAttachmentsOptions struct {
 func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(instanceID string, profileID string) *ListAttachmentsOptions {
 	return &ListAttachmentsOptions{
 		InstanceID: core.StringPtr(instanceID),
-		ProfileID: core.StringPtr(profileID),
+		ProfileID:  core.StringPtr(profileID),
 	}
 }
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -43,16 +43,15 @@ type SecurityAndComplianceCenterApiV3 struct {
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://us-south.compliance.cloud.ibm.com/instances/instance_id/v3"
+const DefaultServiceURL = "https://us-south.compliance.cloud.ibm.com"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "security_and_compliance_center_api"
 
-// const ParameterizedServiceURL = "https://{region}.cloud.ibm.com/instances/{instance_id}/v3"
-const ParameterizedServiceURL = "https://{region}.compliance.cloud.ibm.com/"
+const ParameterizedServiceURL = "https://{region}.compliance.cloud.ibm.com"
 
 var defaultUrlVariables = map[string]string{
-	"region": "us-south",
+	"region":      "us-south",
 }
 
 // SecurityAndComplianceCenterApiV3Options : Service options
@@ -200,10 +199,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetSetti
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	pathParamsMap := map[string]string{
-		"instance_id": *getSettingsOptions.InstanceID,
-	}
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/settings`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getSettingsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/settings`, nil)
 	if err != nil {
 		return
 	}
@@ -262,13 +259,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdateSe
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *updateSettingsOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/settings`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateSettingsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/settings`, nil)
 	if err != nil {
 		return
 	}
@@ -338,13 +333,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) PostTest
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *postTestEventOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/test_event`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *postTestEventOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/test_event`, nil)
 	if err != nil {
 		return
 	}
@@ -406,13 +399,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListCont
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *listControlLibrariesOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/instances/{instance_id}/v3/control_libraries`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listControlLibrariesOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries`, nil)
 	if err != nil {
 		return
 	}
@@ -488,13 +479,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateCu
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *createCustomControlLibraryOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createCustomControlLibraryOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries`, nil)
 	if err != nil {
 		return
 	}
@@ -590,14 +579,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	}
 
 	pathParamsMap := map[string]string{
-		"instance_id": *deleteCustomControlLibraryOptions.InstanceID,
 		"control_libraries_id": *deleteCustomControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomControlLibraryOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -664,14 +653,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetContr
 	}
 
 	pathParamsMap := map[string]string{
-		"instance_id": *getControlLibraryOptions.InstanceID,
 		"control_libraries_id": *getControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getControlLibraryOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -737,14 +726,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceC
 	}
 
 	pathParamsMap := map[string]string{
-		"instance_id": *replaceCustomControlLibraryOptions.InstanceID,
 		"control_libraries_id": *replaceCustomControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceCustomControlLibraryOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -854,13 +843,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProf
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *listProfilesOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/profiles`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProfilesOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles`, nil)
 	if err != nil {
 		return
 	}
@@ -931,13 +918,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 		return
 	}
 
-	pathParamsMap := map[string]string{
-		"instance_id": *createProfileOptions.InstanceID,
-	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/profiles`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles`, nil)
 	if err != nil {
 		return
 	}
@@ -5089,9 +5073,6 @@ type CreateCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateCustomControlLibraryOptions.ControlLibraryType property.
@@ -5177,12 +5158,6 @@ func (options *CreateCustomControlLibraryOptions) SetHeaders(param map[string]st
 	return options
 }
 
-// SetInstanceID : Allow user to set the InstanceID
-func (options *CreateCustomControlLibraryOptions) SetInstanceID(instanceID string) *CreateCustomControlLibraryOptions {
-	options.InstanceID = core.StringPtr(instanceID)
-	return options
-}
-
 // CreateProfileOptions : The CreateProfile options.
 type CreateProfileOptions struct {
 	// The name of the profile.
@@ -5212,9 +5187,6 @@ type CreateProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateProfileOptions.ProfileType property.
@@ -5595,9 +5567,6 @@ type DeleteCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomControlLibraryOptions : Instantiate DeleteCustomControlLibraryOptions
@@ -5628,12 +5597,6 @@ func (_options *DeleteCustomControlLibraryOptions) SetXRequestID(xRequestID stri
 // SetHeaders : Allow user to set Headers
 func (options *DeleteCustomControlLibraryOptions) SetHeaders(param map[string]string) *DeleteCustomControlLibraryOptions {
 	options.Headers = param
-	return options
-}
-
-// SetInstanceID : Allow user to set the InstanceID
-func (options *DeleteCustomControlLibraryOptions) SetInstanceID(instanceID string) *DeleteCustomControlLibraryOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -6188,9 +6151,6 @@ type GetControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
@@ -7047,9 +7007,6 @@ type GetSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetSettingsOptions : Instantiate GetSettingsOptions
@@ -7072,12 +7029,6 @@ func (_options *GetSettingsOptions) SetXRequestID(xRequestID string) *GetSetting
 // SetHeaders : Allow user to set Headers
 func (options *GetSettingsOptions) SetHeaders(param map[string]string) *GetSettingsOptions {
 	options.Headers = param
-	return options
-}
-
-// SetInstanceID: Allow user to set InstanceID
-func (options *GetSettingsOptions) SetInstanceID(instanceID string) *GetSettingsOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -7360,9 +7311,6 @@ type ListControlLibrariesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListControlLibrariesOptions : Instantiate ListControlLibrariesOptions
@@ -7429,9 +7377,6 @@ type ListProfilesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListProfilesOptions : Instantiate ListProfilesOptions
@@ -7472,11 +7417,6 @@ func (_options *ListProfilesOptions) SetStart(start string) *ListProfilesOptions
 // SetHeaders : Allow user to set Headers
 func (options *ListProfilesOptions) SetHeaders(param map[string]string) *ListProfilesOptions {
 	options.Headers = param
-	return options
-}
-
-func (options *ListProfilesOptions) SetInstanceID(instanceID string) *ListProfilesOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -8301,9 +8241,6 @@ type PostTestEventOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the Instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewPostTestEventOptions : Instantiate PostTestEventOptions
@@ -8327,12 +8264,6 @@ func (_options *PostTestEventOptions) SetXRequestID(xRequestID string) *PostTest
 func (options *PostTestEventOptions) SetHeaders(param map[string]string) *PostTestEventOptions {
 	options.Headers = param
 	return options
-}
-
-// SetInstanceID : Allow user to set InstanceID
-func (_options *PostTestEventOptions) SetInstanceID(instanceID string) *PostTestEventOptions {
-	_options.InstanceID = core.StringPtr(instanceID)
-	return _options
 }
 
 // Profile : The response body of the profile.
@@ -9116,9 +9047,6 @@ type ReplaceCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the ReplaceCustomControlLibraryOptions.ControlLibraryType property.
@@ -9252,12 +9180,6 @@ func (_options *ReplaceCustomControlLibraryOptions) SetXRequestID(xRequestID str
 // SetHeaders : Allow user to set Headers
 func (options *ReplaceCustomControlLibraryOptions) SetHeaders(param map[string]string) *ReplaceCustomControlLibraryOptions {
 	options.Headers = param
-	return options
-}
-
-// SetInstanceID : Allow user to set the InstanceID
-func (options *ReplaceCustomControlLibraryOptions) SetInstanceID(instanceID string) *ReplaceCustomControlLibraryOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -9512,9 +9434,6 @@ type ReplaceProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the ReplaceProfileOptions.ProfileType property.
@@ -9587,12 +9506,6 @@ func (_options *ReplaceProfileOptions) SetXRequestID(xRequestID string) *Replace
 // SetHeaders : Allow user to set Headers
 func (options *ReplaceProfileOptions) SetHeaders(param map[string]string) *ReplaceProfileOptions {
 	options.Headers = param
-	return options
-}
-
-// SetInstanceID : Allow user to set the InstanceID
-func (options *ReplaceProfileOptions) SetInstanceID(instanceID string) *ReplaceProfileOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -11299,9 +11212,6 @@ type UpdateSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
-
-	// ID of the instance
-	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewUpdateSettingsOptions : Instantiate UpdateSettingsOptions
@@ -11336,12 +11246,6 @@ func (_options *UpdateSettingsOptions) SetXRequestID(xRequestID string) *UpdateS
 // SetHeaders : Allow user to set Headers
 func (options *UpdateSettingsOptions) SetHeaders(param map[string]string) *UpdateSettingsOptions {
 	options.Headers = param
-	return options
-}
-
-// SetInstanceID : Allow user to set the InstanceID
-func (options *UpdateSettingsOptions) SetInstanceID(instanceID string) *UpdateSettingsOptions {
-	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -12192,4 +12096,9 @@ func (pager *ReportResourcesPager) GetNext() (page []Resource, err error) {
 // GetAll invokes GetAllWithContext() using context.Background() as the Context parameter.
 func (pager *ReportResourcesPager) GetAll() (allItems []Resource, err error) {
 	return pager.GetAllWithContext(context.Background())
+}
+
+// getInstanceBasedURL uses the baseURL and instanceID to return the correct endpoint URL
+func getInstanceBasedURL(baseURL, instanceID string) string {
+	return baseURL + "/instances/" + instanceID + "/v3"
 }

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -203,7 +203,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetSetti
 	pathParamsMap := map[string]string{
 		"instance_id": *getSettingsOptions.InstanceID,
 	}
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/settings`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/settings`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -268,7 +268,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdateSe
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/settings`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/settings`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -344,7 +344,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) PostTest
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/test_event`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/test_event`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -412,7 +412,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListCont
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/control_libraries`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/instances/{instance_id}/v3/control_libraries`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -494,7 +494,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateCu
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/control_libraries`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -590,13 +590,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	}
 
 	pathParamsMap := map[string]string{
+		"instance_id": *deleteCustomControlLibraryOptions.InstanceID,
 		"control_libraries_id": *deleteCustomControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -663,13 +664,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetContr
 	}
 
 	pathParamsMap := map[string]string{
+		"instance_id": *getControlLibraryOptions.InstanceID,
 		"control_libraries_id": *getControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -735,13 +737,14 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceC
 	}
 
 	pathParamsMap := map[string]string{
+		"instance_id": *replaceCustomControlLibraryOptions.InstanceID,
 		"control_libraries_id": *replaceCustomControlLibraryOptions.ControlLibrariesID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/control_libraries/{control_libraries_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/control_libraries/{control_libraries_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -851,10 +854,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProf
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *listProfilesOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/profiles`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -925,10 +931,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *createProfileOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `instances/{instance_id}/v3/profiles`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -5203,6 +5212,9 @@ type CreateProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateProfileOptions.ProfileType property.
@@ -5583,6 +5595,9 @@ type DeleteCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomControlLibraryOptions : Instantiate DeleteCustomControlLibraryOptions
@@ -5613,6 +5628,12 @@ func (_options *DeleteCustomControlLibraryOptions) SetXRequestID(xRequestID stri
 // SetHeaders : Allow user to set Headers
 func (options *DeleteCustomControlLibraryOptions) SetHeaders(param map[string]string) *DeleteCustomControlLibraryOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID : Allow user to set the InstanceID
+func (options *DeleteCustomControlLibraryOptions) SetInstanceID(instanceID string) *DeleteCustomControlLibraryOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -6167,6 +6188,9 @@ type GetControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
@@ -7405,6 +7429,9 @@ type ListProfilesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListProfilesOptions : Instantiate ListProfilesOptions
@@ -7445,6 +7472,11 @@ func (_options *ListProfilesOptions) SetStart(start string) *ListProfilesOptions
 // SetHeaders : Allow user to set Headers
 func (options *ListProfilesOptions) SetHeaders(param map[string]string) *ListProfilesOptions {
 	options.Headers = param
+	return options
+}
+
+func (options *ListProfilesOptions) SetInstanceID(instanceID string) *ListProfilesOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -9084,6 +9116,9 @@ type ReplaceCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the ReplaceCustomControlLibraryOptions.ControlLibraryType property.
@@ -9217,6 +9252,12 @@ func (_options *ReplaceCustomControlLibraryOptions) SetXRequestID(xRequestID str
 // SetHeaders : Allow user to set Headers
 func (options *ReplaceCustomControlLibraryOptions) SetHeaders(param map[string]string) *ReplaceCustomControlLibraryOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID : Allow user to set the InstanceID
+func (options *ReplaceCustomControlLibraryOptions) SetInstanceID(instanceID string) *ReplaceCustomControlLibraryOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -9471,6 +9512,9 @@ type ReplaceProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the ReplaceProfileOptions.ProfileType property.
@@ -9543,6 +9587,12 @@ func (_options *ReplaceProfileOptions) SetXRequestID(xRequestID string) *Replace
 // SetHeaders : Allow user to set Headers
 func (options *ReplaceProfileOptions) SetHeaders(param map[string]string) *ReplaceProfileOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID : Allow user to set the InstanceID
+func (options *ReplaceProfileOptions) SetInstanceID(instanceID string) *ReplaceProfileOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -6423,6 +6423,7 @@ type GetControlLibraryOptions struct {
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
 func (*SecurityAndComplianceCenterApiV3) NewGetControlLibraryOptions(instanceID string, controlLibrariesID string) *GetControlLibraryOptions {
 	return &GetControlLibraryOptions{
+		InstanceID:         core.StringPtr(instanceID),
 		ControlLibrariesID: core.StringPtr(controlLibrariesID),
 	}
 }
@@ -6786,8 +6787,10 @@ type GetProviderTypesInstancesOptions struct {
 }
 
 // NewGetProviderTypesInstancesOptions : Instantiate GetProviderTypesInstancesOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypesInstancesOptions() *GetProviderTypesInstancesOptions {
-	return &GetProviderTypesInstancesOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypesInstancesOptions(instanceID string) *GetProviderTypesInstancesOptions {
+	return &GetProviderTypesInstancesOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstance : Allow user to set Instantiate
@@ -7667,8 +7670,9 @@ type ListAttachmentsOptions struct {
 }
 
 // NewListAttachmentsOptions : Instantiate ListAttachmentsOptions
-func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(profileID string) *ListAttachmentsOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListAttachmentsOptions(instanceID string, profileID string) *ListAttachmentsOptions {
 	return &ListAttachmentsOptions{
+		InstanceID: core.StringPtr(instanceID),
 		ProfileID: core.StringPtr(profileID),
 	}
 }
@@ -7940,7 +7944,7 @@ type ListProviderTypesOptions struct {
 }
 
 // NewListProviderTypesOptions : Instantiate ListProviderTypesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions(instanceID string) *ListProviderTypesOptions {
+func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions() *ListProviderTypesOptions {
 	return &ListProviderTypesOptions{}
 }
 
@@ -8396,8 +8400,10 @@ type ListRulesOptions struct {
 }
 
 // NewListRulesOptions : Instantiate ListRulesOptions
-func (*SecurityAndComplianceCenterApiV3) NewListRulesOptions() *ListRulesOptions {
-	return &ListRulesOptions{}
+func (*SecurityAndComplianceCenterApiV3) NewListRulesOptions(instanceID string) *ListRulesOptions {
+	return &ListRulesOptions{
+		InstanceID: core.StringPtr(instanceID),
+	}
 }
 
 // SetInstanceID : Allow user to set InstanceID

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -48,11 +48,11 @@ const DefaultServiceURL = "https://us-south.compliance.cloud.ibm.com/instances/i
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "security_and_compliance_center_api"
 
-const ParameterizedServiceURL = "https://{region}.cloud.ibm.com/instances/{instance_id}/v3"
+// const ParameterizedServiceURL = "https://{region}.cloud.ibm.com/instances/{instance_id}/v3"
+const ParameterizedServiceURL = "https://{region}.compliance.cloud.ibm.com/"
 
 var defaultUrlVariables = map[string]string{
-	"region":      "us-south.compliance",
-	"instance_id": "instance_id",
+	"region": "us-south",
 }
 
 // SecurityAndComplianceCenterApiV3Options : Service options
@@ -119,7 +119,18 @@ func NewSecurityAndComplianceCenterApiV3(options *SecurityAndComplianceCenterApi
 
 // GetServiceURLForRegion returns the service URL to be used for the specified region
 func GetServiceURLForRegion(region string) (string, error) {
-	return "", fmt.Errorf("service does not support regional URLs")
+	endpoints := map[string]string{
+		"au-syd":   "https://au-syd.compliance.cloud.ibm.com",   // The API endpoint in the au-syd region
+		"ca-tor":   "https://ca-tor.compliance.cloud.ibm.com",   // The API endpoint in the ca-tor region
+		"eu-de":    "https://eu-de.compliance.cloud.ibm.com",    // The API endpoint in the eu-de region
+		"eu-fr2":   "https://eu-fr2.compliance.cloud.ibm.com",   // The API endpoint in the eu-fr2 region
+		"us-south": "https://us-south.compliance.cloud.ibm.com", // The API endpoint in the us-south region
+	}
+
+	if url, ok := endpoints[region]; ok {
+		return url, nil
+	}
+	return "", fmt.Errorf("service URL for region '%s' not found", region)
 }
 
 // Clone makes a copy of "securityAndComplianceCenterApi" suitable for processing requests.
@@ -189,7 +200,10 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetSetti
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/settings`, nil)
+	pathParamsMap := map[string]string{
+		"instance_id": *getSettingsOptions.InstanceID,
+	}
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/settings`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -248,10 +262,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdateSe
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *updateSettingsOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/settings`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/settings`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -321,10 +338,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) PostTest
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *postTestEventOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/test_event`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/test_event`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -386,10 +406,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListCont
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *listControlLibrariesOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/control_libraries`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/control_libraries`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -465,10 +488,13 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateCu
 		return
 	}
 
+	pathParamsMap := map[string]string{
+		"instance_id": *createCustomControlLibraryOptions.InstanceID,
+	}
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/control_libraries`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `{instance_id}/control_libraries`, nil)
 	if err != nil {
 		return
 	}
@@ -5054,6 +5080,9 @@ type CreateCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateCustomControlLibraryOptions.ControlLibraryType property.
@@ -5136,6 +5165,12 @@ func (_options *CreateCustomControlLibraryOptions) SetXRequestID(xRequestID stri
 // SetHeaders : Allow user to set Headers
 func (options *CreateCustomControlLibraryOptions) SetHeaders(param map[string]string) *CreateCustomControlLibraryOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID : Allow user to set the InstanceID
+func (options *CreateCustomControlLibraryOptions) SetInstanceID(instanceID string) *CreateCustomControlLibraryOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -6988,6 +7023,9 @@ type GetSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetSettingsOptions : Instantiate GetSettingsOptions
@@ -7010,6 +7048,12 @@ func (_options *GetSettingsOptions) SetXRequestID(xRequestID string) *GetSetting
 // SetHeaders : Allow user to set Headers
 func (options *GetSettingsOptions) SetHeaders(param map[string]string) *GetSettingsOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID: Allow user to set InstanceID
+func (options *GetSettingsOptions) SetInstanceID(instanceID string) *GetSettingsOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 
@@ -7292,6 +7336,9 @@ type ListControlLibrariesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListControlLibrariesOptions : Instantiate ListControlLibrariesOptions
@@ -8222,6 +8269,9 @@ type PostTestEventOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the Instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewPostTestEventOptions : Instantiate PostTestEventOptions
@@ -8245,6 +8295,12 @@ func (_options *PostTestEventOptions) SetXRequestID(xRequestID string) *PostTest
 func (options *PostTestEventOptions) SetHeaders(param map[string]string) *PostTestEventOptions {
 	options.Headers = param
 	return options
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *PostTestEventOptions) SetInstanceID(instanceID string) *PostTestEventOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // Profile : The response body of the profile.
@@ -11193,6 +11249,9 @@ type UpdateSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewUpdateSettingsOptions : Instantiate UpdateSettingsOptions
@@ -11227,6 +11286,12 @@ func (_options *UpdateSettingsOptions) SetXRequestID(xRequestID string) *UpdateS
 // SetHeaders : Allow user to set Headers
 func (options *UpdateSettingsOptions) SetHeaders(param map[string]string) *UpdateSettingsOptions {
 	options.Headers = param
+	return options
+}
+
+// SetInstanceID : Allow user to set the InstanceID
+func (options *UpdateSettingsOptions) SetInstanceID(instanceID string) *UpdateSettingsOptions {
+	options.InstanceID = core.StringPtr(instanceID)
 	return options
 }
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -51,7 +51,7 @@ const DefaultServiceName = "security_and_compliance_center_api"
 const ParameterizedServiceURL = "https://{region}.compliance.cloud.ibm.com"
 
 var defaultUrlVariables = map[string]string{
-	"region":      "us-south",
+	"region": "us-south",
 }
 
 // SecurityAndComplianceCenterApiV3Options : Service options
@@ -921,11 +921,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProfileOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles`, nil)
 	if err != nil {
 		return
 	}
-
 	for headerName, headerValue := range createProfileOptions.Headers {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1011,7 +1011,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteCu
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteCustomProfileOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1079,7 +1080,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1148,7 +1150,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1230,7 +1233,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRule
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/rules`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listRulesOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/rules`, nil)
 	if err != nil {
 		return
 	}
@@ -1304,7 +1308,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateRu
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/rules`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createRuleOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/rules`, nil)
 	if err != nil {
 		return
 	}
@@ -1399,7 +1404,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeleteRu
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/rules/{rule_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteRuleOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1454,7 +1460,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRuleW
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/rules/{rule_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getRuleOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(getRuleOptions, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1522,7 +1529,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceR
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/rules/{rule_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceRuleOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1622,7 +1630,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListAtta
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1697,7 +1706,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateAt
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createAttachmentOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1779,7 +1789,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProfileAttachmentOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1848,7 +1859,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProfi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProfileAttachmentOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -1917,7 +1929,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ReplaceP
 	builder := core.NewRequestBuilder(core.PUT)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *replaceProfileAttachmentOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/profiles/{profile_id}/attachments/{attachment_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2037,7 +2050,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreateSc
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/scans`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createScanOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/scans`, nil)
 	if err != nil {
 		return
 	}
@@ -2108,7 +2122,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListAtta
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/attachments`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listAttachmentsAccountOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/attachments`, nil)
 	if err != nil {
 		return
 	}
@@ -2174,7 +2189,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetLates
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/latest`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getLatestReportsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/latest`, nil)
 	if err != nil {
 		return
 	}
@@ -2237,7 +2253,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports`, nil)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports`, nil)
 	if err != nil {
 		return
 	}
@@ -2326,7 +2343,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2393,7 +2411,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/summary`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportSummaryOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/summary`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2460,7 +2479,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/download`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportEvaluationOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/download`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2520,7 +2540,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/controls`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportControlsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/controls`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2607,7 +2628,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/rules/{rule_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportRuleOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2674,7 +2696,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/evaluations`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportEvaluationsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/evaluations`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2763,7 +2786,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListRepo
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/resources`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listReportResourcesOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/resources`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2855,7 +2879,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/tags`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportTagsOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/tags`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2922,7 +2947,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRepor
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/reports/{report_id}/violations_drift`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getReportViolationsDriftOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/reports/{report_id}/violations_drift`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -2986,7 +3012,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProv
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types`, nil)
 	if err != nil {
 		return
 	}
@@ -3053,7 +3079,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types/{provider_type_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3120,7 +3146,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProv
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProviderTypeInstancesOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3187,7 +3214,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) CreatePr
 	builder := core.NewRequestBuilder(core.POST)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *createProviderTypeInstanceOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3267,7 +3295,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) DeletePr
 	builder := core.NewRequestBuilder(core.DELETE)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *deleteProviderTypeInstanceOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3324,7 +3353,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProviderTypeInstanceOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3391,7 +3421,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) UpdatePr
 	builder := core.NewRequestBuilder(core.PATCH)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
+	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *updateProviderTypeInstanceOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}/provider_type_instances/{provider_type_instance_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -3462,7 +3493,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/provider_types_instances`, nil)
+	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types_instances`, nil)
 	if err != nil {
 		return
 	}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -3612,7 +3612,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types_instances`, nil)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProviderTypesInstancesOptions.InstanceID)
+	if err != nil {
+		return
+	}
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types_instances`, nil)
 	if err != nil {
 		return
 	}
@@ -6765,6 +6769,8 @@ func (options *GetProviderTypeInstanceOptions) SetHeaders(param map[string]strin
 
 // GetProviderTypesInstancesOptions : The GetProviderTypesInstances options.
 type GetProviderTypesInstancesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
@@ -6782,6 +6788,12 @@ type GetProviderTypesInstancesOptions struct {
 // NewGetProviderTypesInstancesOptions : Instantiate GetProviderTypesInstancesOptions
 func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypesInstancesOptions() *GetProviderTypesInstancesOptions {
 	return &GetProviderTypesInstancesOptions{}
+}
+
+// SetInstance : Allow user to set Instantiate
+func (_options *GetProviderTypesInstancesOptions) SetInstanceID(instanceID string) *GetProviderTypesInstancesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -1461,7 +1461,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetRuleW
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
 	instanceURL := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getRuleOptions.InstanceID)
-	_, err = builder.ResolveRequestURL(getRuleOptions, `/rules/{rule_id}`, pathParamsMap)
+	_, err = builder.ResolveRequestURL(instanceURL, `/rules/{rule_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}
@@ -5008,6 +5008,9 @@ func UnmarshalControlsInControlLib(m map[string]json.RawMessage, result interfac
 
 // CreateAttachmentOptions : The CreateAttachment options.
 type CreateAttachmentOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The profile ID.
 	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
@@ -5104,6 +5107,9 @@ type CreateCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateCustomControlLibraryOptions.ControlLibraryType property.
@@ -5218,6 +5224,9 @@ type CreateProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the CreateProfileOptions.ProfileType property.
@@ -5288,6 +5297,9 @@ func (options *CreateProfileOptions) SetHeaders(param map[string]string) *Create
 
 // CreateProviderTypeInstanceOptions : The CreateProviderTypeInstance options.
 type CreateProviderTypeInstanceOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -5356,6 +5368,9 @@ func (options *CreateProviderTypeInstanceOptions) SetHeaders(param map[string]st
 
 // CreateRuleOptions : The CreateRule options.
 type CreateRuleOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The rule description.
 	Description *string `json:"description" validate:"required"`
 
@@ -5469,6 +5484,9 @@ func (options *CreateRuleOptions) SetHeaders(param map[string]string) *CreateRul
 
 // CreateScanOptions : The CreateScan options.
 type CreateScanOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The attachment ID of a profile.
 	AttachmentID *string `json:"attachment_id" validate:"required"`
 
@@ -5598,6 +5616,9 @@ type DeleteCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomControlLibraryOptions : Instantiate DeleteCustomControlLibraryOptions
@@ -5648,6 +5669,9 @@ type DeleteCustomProfileOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewDeleteCustomProfileOptions : Instantiate DeleteCustomProfileOptions
@@ -5683,6 +5707,9 @@ func (options *DeleteCustomProfileOptions) SetHeaders(param map[string]string) *
 
 // DeleteProfileAttachmentOptions : The DeleteProfileAttachment options.
 type DeleteProfileAttachmentOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The attachment ID.
 	AttachmentID *string `json:"attachment_id" validate:"required,ne="`
 
@@ -5743,6 +5770,9 @@ func (options *DeleteProfileAttachmentOptions) SetHeaders(param map[string]strin
 
 // DeleteProviderTypeInstanceOptions : The DeleteProviderTypeInstance options.
 type DeleteProviderTypeInstanceOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -5803,6 +5833,9 @@ func (options *DeleteProviderTypeInstanceOptions) SetHeaders(param map[string]st
 
 // DeleteRuleOptions : The DeleteRule options.
 type DeleteRuleOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the corresponding rule.
 	RuleID *string `json:"rule_id" validate:"required,ne="`
 
@@ -6182,6 +6215,9 @@ type GetControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetControlLibraryOptions : Instantiate GetControlLibraryOptions
@@ -6217,6 +6253,9 @@ func (options *GetControlLibraryOptions) SetHeaders(param map[string]string) *Ge
 
 // GetLatestReportsOptions : The GetLatestReports options.
 type GetLatestReportsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -6266,6 +6305,9 @@ func (options *GetLatestReportsOptions) SetHeaders(param map[string]string) *Get
 
 // GetProfileAttachmentOptions : The GetProfileAttachment options.
 type GetProfileAttachmentOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The attachment ID.
 	AttachmentID *string `json:"attachment_id" validate:"required,ne="`
 
@@ -6326,6 +6368,9 @@ func (options *GetProfileAttachmentOptions) SetHeaders(param map[string]string) 
 
 // GetProfileOptions : The GetProfile options.
 type GetProfileOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The profile ID.
 	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
@@ -6376,6 +6421,9 @@ func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfil
 
 // GetProviderTypeByIdOptions : The GetProviderTypeByID options.
 type GetProviderTypeByIdOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -6426,6 +6474,9 @@ func (options *GetProviderTypeByIdOptions) SetHeaders(param map[string]string) *
 
 // GetProviderTypeInstanceOptions : The GetProviderTypeInstance options.
 type GetProviderTypeInstanceOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -6525,6 +6576,9 @@ func (options *GetProviderTypesInstancesOptions) SetHeaders(param map[string]str
 
 // GetReportControlsOptions : The GetReportControls options.
 type GetReportControlsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6648,6 +6702,9 @@ func (options *GetReportControlsOptions) SetHeaders(param map[string]string) *Ge
 
 // GetReportEvaluationOptions : The GetReportEvaluation options.
 type GetReportEvaluationOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6707,6 +6764,9 @@ func (options *GetReportEvaluationOptions) SetHeaders(param map[string]string) *
 
 // GetReportOptions : The GetReport options.
 type GetReportOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6757,6 +6817,9 @@ func (options *GetReportOptions) SetHeaders(param map[string]string) *GetReportO
 
 // GetReportRuleOptions : The GetReportRule options.
 type GetReportRuleOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6817,6 +6880,9 @@ func (options *GetReportRuleOptions) SetHeaders(param map[string]string) *GetRep
 
 // GetReportSummaryOptions : The GetReportSummary options.
 type GetReportSummaryOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6867,6 +6933,9 @@ func (options *GetReportSummaryOptions) SetHeaders(param map[string]string) *Get
 
 // GetReportTagsOptions : The GetReportTags options.
 type GetReportTagsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6917,6 +6986,9 @@ func (options *GetReportTagsOptions) SetHeaders(param map[string]string) *GetRep
 
 // GetReportViolationsDriftOptions : The GetReportViolationsDrift options.
 type GetReportViolationsDriftOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -6976,6 +7048,9 @@ func (options *GetReportViolationsDriftOptions) SetHeaders(param map[string]stri
 
 // GetRuleOptions : The GetRule options.
 type GetRuleOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the corresponding rule.
 	RuleID *string `json:"rule_id" validate:"required,ne="`
 
@@ -7038,6 +7113,9 @@ type GetSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// The ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewGetSettingsOptions : Instantiate GetSettingsOptions
@@ -7196,6 +7274,9 @@ func UnmarshalLastScan(m map[string]json.RawMessage, result interface{}) (err er
 
 // ListAttachmentsAccountOptions : The ListAttachmentsAccount options.
 type ListAttachmentsAccountOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7253,6 +7334,9 @@ func (options *ListAttachmentsAccountOptions) SetHeaders(param map[string]string
 
 // ListAttachmentsOptions : The ListAttachments options.
 type ListAttachmentsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The profile ID.
 	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
@@ -7342,6 +7426,9 @@ type ListControlLibrariesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListControlLibrariesOptions : Instantiate ListControlLibrariesOptions
@@ -7408,6 +7495,9 @@ type ListProfilesOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewListProfilesOptions : Instantiate ListProfilesOptions
@@ -7453,6 +7543,9 @@ func (options *ListProfilesOptions) SetHeaders(param map[string]string) *ListPro
 
 // ListProviderTypeInstancesOptions : The ListProviderTypeInstances options.
 type ListProviderTypeInstancesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -7503,6 +7596,9 @@ func (options *ListProviderTypeInstancesOptions) SetHeaders(param map[string]str
 
 // ListProviderTypesOptions : The ListProviderTypes options.
 type ListProviderTypesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7542,6 +7638,9 @@ func (options *ListProviderTypesOptions) SetHeaders(param map[string]string) *Li
 
 // ListReportEvaluationsOptions : The ListReportEvaluations options.
 type ListReportEvaluationsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -7664,6 +7763,9 @@ func (options *ListReportEvaluationsOptions) SetHeaders(param map[string]string)
 
 // ListReportResourcesOptions : The ListReportResources options.
 type ListReportResourcesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the scan that is associated with a report.
 	ReportID *string `json:"report_id" validate:"required,ne="`
 
@@ -7806,6 +7908,9 @@ func (options *ListReportResourcesOptions) SetHeaders(param map[string]string) *
 
 // ListReportsOptions : The ListReports options.
 type ListReportsOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7916,6 +8021,9 @@ func (options *ListReportsOptions) SetHeaders(param map[string]string) *ListRepo
 
 // ListRulesOptions : The ListRules options.
 type ListRulesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this header is not supplied in a request, the service generates a random (version 4) UUID.
@@ -8272,6 +8380,9 @@ type PostTestEventOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewPostTestEventOptions : Instantiate PostTestEventOptions
@@ -9078,6 +9189,9 @@ type ReplaceCustomControlLibraryOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // Constants associated with the ReplaceCustomControlLibraryOptions.ControlLibraryType property.
@@ -9228,8 +9342,8 @@ type ReplaceProfileAttachmentOptions struct {
 	// The account ID that is associated to the attachment.
 	AccountID *string `json:"account_id,omitempty"`
 
-	// The instance ID of the account that is associated to the attachment.
-	InstanceID *string `json:"instance_id,omitempty"`
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 
 	// The scope payload for the multi cloud feature.
 	Scope []MultiCloudScope `json:"scope,omitempty"`
@@ -9435,6 +9549,9 @@ func (options *ReplaceProfileAttachmentOptions) SetHeaders(param map[string]stri
 
 // ReplaceProfileOptions : The ReplaceProfile options.
 type ReplaceProfileOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The profile ID.
 	ProfileID *string `json:"profile_id" validate:"required,ne="`
 
@@ -9542,6 +9659,9 @@ func (options *ReplaceProfileOptions) SetHeaders(param map[string]string) *Repla
 
 // ReplaceRuleOptions : The ReplaceRule options.
 type ReplaceRuleOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The ID of the corresponding rule.
 	RuleID *string `json:"rule_id" validate:"required,ne="`
 
@@ -11147,6 +11267,9 @@ func UnmarshalTestEvent(m map[string]json.RawMessage, result interface{}) (err e
 
 // UpdateProviderTypeInstanceOptions : The UpdateProviderTypeInstance options.
 type UpdateProviderTypeInstanceOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -11243,6 +11366,9 @@ type UpdateSettingsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
 }
 
 // NewUpdateSettingsOptions : Instantiate UpdateSettingsOptions

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_examples_test.go
@@ -161,7 +161,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nGetSettings() result:")
 			// begin-get_settings
 
-			getSettingsOptions := securityAndComplianceCenterApiService.NewGetSettingsOptions()
+			getSettingsOptions := securityAndComplianceCenterApiService.NewGetSettingsOptions(instanceID)
 			getSettingsOptions.SetXCorrelationID("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 
 			settings, response, err := securityAndComplianceCenterApiService.GetSettings(getSettingsOptions)
@@ -225,7 +225,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			createRuleOptions := securityAndComplianceCenterApiService.NewCreateRuleOptions(
-				"Example rule",
+				instanceID,
+				"scc-go-sdk example rule",
 				targetModel,
 				requiredConfigModel,
 			)
@@ -254,6 +255,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_rule
 
 			getRuleOptions := securityAndComplianceCenterApiService.NewGetRuleOptions(
+				instanceID,
 				ruleIdLink,
 			)
 
@@ -277,7 +279,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nGetLatestReports() result:")
 			// begin-get_latest_reports
 
-			getLatestReportsOptions := securityAndComplianceCenterApiService.NewGetLatestReportsOptions()
+			getLatestReportsOptions := securityAndComplianceCenterApiService.NewGetLatestReportsOptions(instanceID)
 			getLatestReportsOptions.SetSort("profile_name")
 
 			reportLatest, response, err := securityAndComplianceCenterApiService.GetLatestReports(getLatestReportsOptions)
@@ -322,7 +324,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 				BucketLocation: &objectStorageLocationForUpdateSettingsLink,
 			}
 
-			updateSettingsOptions := securityAndComplianceCenterApiService.NewUpdateSettingsOptions()
+			updateSettingsOptions := securityAndComplianceCenterApiService.NewUpdateSettingsOptions(instanceID)
 			updateSettingsOptions.SetEventNotifications(eventNotificationsModel)
 			updateSettingsOptions.SetObjectStorage(objectStorageModel)
 			updateSettingsOptions.SetXCorrelationID("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -403,8 +405,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			createCustomControlLibraryOptions := securityAndComplianceCenterApiService.NewCreateCustomControlLibraryOptions(
-				"IBM Cloud for Financial Services",
-				"IBM Cloud for Financial Services",
+				instanceID,
+				"scc-go-sdk Control Library",
+				"This is a demo library for scc-go-sdk",
 				"custom",
 				[]securityandcompliancecenterapiv3.ControlsInControlLib{*controlsInControlLibModel},
 			)
@@ -421,7 +424,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// end-create_custom_control_library
 
 			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(controlLibrary).ToNot(BeNil())
 
 			controlLibraryIdLink = *controlLibrary.ID
@@ -431,6 +434,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListControlLibraries() result:")
 			// begin-list_control_libraries
 			listControlLibrariesOptions := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{
+				InstanceID:         &instanceID,
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
 				Limit:              core.Int64Ptr(int64(50)),
@@ -459,6 +463,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_control_library
 
 			getControlLibraryOptions := securityAndComplianceCenterApiService.NewGetControlLibraryOptions(
+				instanceID,
 				controlLibraryIdLink,
 			)
 
@@ -519,6 +524,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			replaceCustomControlLibraryOptions := securityAndComplianceCenterApiService.NewReplaceCustomControlLibraryOptions(
+				instanceID,
 				controlLibraryIdLink,
 			)
 			replaceCustomControlLibraryOptions.SetControlLibraryName("IBM Cloud for Financial Services")
@@ -559,7 +565,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			createProfileOptions := securityAndComplianceCenterApiService.NewCreateProfileOptions(
-				"test_profile1",
+				instanceID,
+				"scc-go-sdk test_profile1",
 				"test_description1",
 				"custom",
 				[]securityandcompliancecenterapiv3.ProfileControlsPrototype{*profileControlsPrototypeModel},
@@ -576,7 +583,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// end-create_profile
 
 			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(profile).ToNot(BeNil())
 
 			profileIdLink = *profile.ID
@@ -586,6 +593,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListProfiles() result:")
 			// begin-list_profiles
 			listProfilesOptions := &securityandcompliancecenterapiv3.ListProfilesOptions{
+				InstanceID:     &instanceID,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),
@@ -614,6 +622,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_profile
 
 			getProfileOptions := securityAndComplianceCenterApiService.NewGetProfileOptions(
+				instanceID,
 				profileIdLink,
 			)
 
@@ -649,6 +658,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			replaceProfileOptions := securityAndComplianceCenterApiService.NewReplaceProfileOptions(
+				instanceID,
 				profileIdLink,
 				"test_profile1",
 				"test_description1",
@@ -674,7 +684,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListRules() result:")
 			// begin-list_rules
 
-			listRulesOptions := securityAndComplianceCenterApiService.NewListRulesOptions()
+			listRulesOptions := securityAndComplianceCenterApiService.NewListRulesOptions(instanceID)
 			listRulesOptions.SetType("system_defined")
 
 			rulesPageBase, response, err := securityAndComplianceCenterApiService.ListRules(listRulesOptions)
@@ -730,6 +740,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			replaceRuleOptions := securityAndComplianceCenterApiService.NewReplaceRuleOptions(
+				instanceID,
 				ruleIdLink,
 				eTagLink,
 				"Example rule",
@@ -802,6 +813,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			createAttachmentOptions := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(
+				instanceID,
 				profileIdLink,
 				[]securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel},
 			)
@@ -816,7 +828,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// end-create_attachment
 
 			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(attachmentPrototype).ToNot(BeNil())
 
 			attachmentIdLink = *attachmentPrototype.Attachments[0].ID
@@ -826,6 +838,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListAttachments() result:")
 			// begin-list_attachments
 			listAttachmentsOptions := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
+				InstanceID:     &instanceID,
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -854,6 +867,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_profile_attachment
 
 			getProfileAttachmentOptions := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(
+				instanceID,
 				attachmentIdLink,
 				profileIdLink,
 			)
@@ -909,6 +923,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			}
 
 			replaceProfileAttachmentOptions := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(
+				instanceID,
 				attachmentIdLink,
 				profileIdLink,
 			)
@@ -938,6 +953,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-create_scan
 
 			createScanOptions := securityAndComplianceCenterApiService.NewCreateScanOptions(
+				instanceID,
 				createScanAttachmentID,
 			)
 
@@ -951,13 +967,14 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// end-create_scan
 
 			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
+			Expect(response.StatusCode).To(Equal(201))
 			Expect(scan).ToNot(BeNil())
 		})
 		It(`ListAttachmentsAccount request example`, func() {
 			fmt.Println("\nListAttachmentsAccount() result:")
 			// begin-list_attachments_account
 			listAttachmentsAccountOptions := &securityandcompliancecenterapiv3.ListAttachmentsAccountOptions{
+				InstanceID:     &instanceID,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Limit:          core.Int64Ptr(int64(10)),
@@ -984,6 +1001,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListReports() result:")
 			// begin-list_reports
 			listReportsOptions := &securityandcompliancecenterapiv3.ListReportsOptions{
+				InstanceID:     &instanceID,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				AttachmentID:   &attachmentIdForReportLink,
@@ -1016,6 +1034,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report
 
 			getReportOptions := securityAndComplianceCenterApiService.NewGetReportOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 
@@ -1037,6 +1056,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report_summary
 
 			getReportSummaryOptions := securityAndComplianceCenterApiService.NewGetReportSummaryOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 
@@ -1058,6 +1078,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report_evaluation
 
 			getReportEvaluationOptions := securityAndComplianceCenterApiService.NewGetReportEvaluationOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 
@@ -1089,6 +1110,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report_controls
 
 			getReportControlsOptions := securityAndComplianceCenterApiService.NewGetReportControlsOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 			getReportControlsOptions.SetStatus("compliant")
@@ -1110,6 +1132,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListReportEvaluations() result:")
 			// begin-list_report_evaluations
 			listReportEvaluationsOptions := &securityandcompliancecenterapiv3.ListReportEvaluationsOptions{
+				InstanceID:     &instanceID,
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -1142,6 +1165,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nListReportResources() result:")
 			// begin-list_report_resources
 			listReportResourcesOptions := &securityandcompliancecenterapiv3.ListReportResourcesOptions{
+				InstanceID:     &instanceID,
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -1176,6 +1200,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report_tags
 
 			getReportTagsOptions := securityAndComplianceCenterApiService.NewGetReportTagsOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 
@@ -1197,6 +1222,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_report_violations_drift
 
 			getReportViolationsDriftOptions := securityAndComplianceCenterApiService.NewGetReportViolationsDriftOptions(
+				instanceID,
 				reportIdForReportLink,
 			)
 
@@ -1232,7 +1258,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(providerTypesCollection).ToNot(BeNil())
 
-			providerTypeIdLink = *providerTypesCollection.ProviderTypes[0].ID
+			// Manual Edit for workload-protection
+			providerTypeIdLink = *providerTypesCollection.ProviderTypes[1].ID
 			fmt.Fprintf(GinkgoWriter, "Saved providerTypeIdLink value: %v\n", providerTypeIdLink)
 		})
 		It(`GetProviderTypeByID request example`, func() {
@@ -1261,6 +1288,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-list_provider_type_instances
 
 			listProviderTypeInstancesOptions := securityAndComplianceCenterApiService.NewListProviderTypeInstancesOptions(
+				instanceID,
 				providerTypeIdLink,
 			)
 
@@ -1282,6 +1310,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-create_provider_type_instance
 
 			createProviderTypeInstanceOptions := &securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions{
+				InstanceID:     &instanceID,
 				ProviderTypeID: &providerTypeIdLink,
 				Name:           core.StringPtr("workload-protection-instance-1"),
 				Attributes:     map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
@@ -1310,6 +1339,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-get_provider_type_instance
 
 			getProviderTypeInstanceOptions := securityAndComplianceCenterApiService.NewGetProviderTypeInstanceOptions(
+				instanceID,
 				providerTypeIdLink,
 				providerTypeInstanceIdLink,
 			)
@@ -1332,6 +1362,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-update_provider_type_instance
 
 			updateProviderTypeInstanceOptions := &securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions{
+				InstanceID:             &instanceID,
 				ProviderTypeID:         &providerTypeIdLink,
 				ProviderTypeInstanceID: &providerTypeInstanceIdLink,
 				Name:                   core.StringPtr("workload-protection-instance-1"),
@@ -1357,7 +1388,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			fmt.Println("\nGetProviderTypesInstances() result:")
 			// begin-get_provider_types_instances
 
-			getProviderTypesInstancesOptions := securityAndComplianceCenterApiService.NewGetProviderTypesInstancesOptions()
+			getProviderTypesInstancesOptions := securityAndComplianceCenterApiService.NewGetProviderTypesInstancesOptions(instanceID)
 
 			providerTypesInstancesResponse, response, err := securityAndComplianceCenterApiService.GetProviderTypesInstances(getProviderTypesInstancesOptions)
 			if err != nil {
@@ -1377,6 +1408,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-delete_profile_attachment
 
 			deleteProfileAttachmentOptions := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(
+				instanceID,
 				attachmentIdLink,
 				profileIdLink,
 			)
@@ -1399,6 +1431,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-delete_custom_profile
 
 			deleteCustomProfileOptions := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(
+				instanceID,
 				profileIdLink,
 			)
 
@@ -1420,6 +1453,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-delete_custom_control_library
 
 			deleteCustomControlLibraryOptions := securityAndComplianceCenterApiService.NewDeleteCustomControlLibraryOptions(
+				instanceID,
 				controlLibraryIdLink,
 			)
 
@@ -1440,6 +1474,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-delete_rule
 
 			deleteRuleOptions := securityAndComplianceCenterApiService.NewDeleteRuleOptions(
+				instanceID,
 				ruleIdLink,
 			)
 
@@ -1460,6 +1495,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Examples Tests`, func() {
 			// begin-delete_provider_type_instance
 
 			deleteProviderTypeInstanceOptions := securityAndComplianceCenterApiService.NewDeleteProviderTypeInstanceOptions(
+				instanceID,
 				providerTypeIdLink,
 				providerTypeInstanceIdLink,
 			)

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -82,9 +83,11 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 	Describe(`External configuration`, func() {
 		It("Successfully load the configuration", func() {
-			_, err = os.Stat(externalConfigFile)
+			wDir, _ := os.Getwd()
+			cleanConfigFile := filepath.Clean(wDir + "/" + externalConfigFile)
+			_, err = os.Stat(cleanConfigFile)
 			if err != nil {
-				Skip("External configuration file not found, skipping tests: " + err.Error())
+				Skip("External configuration file " + externalConfigFile + " not found, skipping tests: " + err.Error())
 			}
 
 			os.Setenv("IBM_CREDENTIALS_FILE", externalConfigFile)
@@ -151,6 +154,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetSettings(getSettingsOptions *GetSettingsOptions)`, func() {
 			getSettingsOptions := &securityandcompliancecenterapiv3.GetSettingsOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				XCorrelationID: core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5"),
 				XRequestID:     core.StringPtr("testString"),
 			}
@@ -213,6 +217,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			createRuleOptions := &securityandcompliancecenterapiv3.CreateRuleOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				Description:    core.StringPtr("Example rule"),
 				Target:         targetModel,
 				RequiredConfig: requiredConfigModel,
@@ -240,6 +245,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetRule(getRuleOptions *GetRuleOptions)`, func() {
 			getRuleOptions := &securityandcompliancecenterapiv3.GetRuleOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				RuleID:         &ruleIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -261,6 +267,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetLatestReports(getLatestReportsOptions *GetLatestReportsOptions)`, func() {
 			getLatestReportsOptions := &securityandcompliancecenterapiv3.GetLatestReportsOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Sort:           core.StringPtr("profile_name"),
@@ -308,6 +315,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			updateSettingsOptions := &securityandcompliancecenterapiv3.UpdateSettingsOptions{
+				InstanceID:         core.StringPtr(instanceID),
 				EventNotifications: eventNotificationsModel,
 				ObjectStorage:      objectStorageModel,
 				XCorrelationID:     core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5"),
@@ -389,6 +397,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			createCustomControlLibraryOptions := &securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions{
+				InstanceID:                core.StringPtr(instanceID),
 				ControlLibraryName:        core.StringPtr("IBM Cloud for Financial Services"),
 				ControlLibraryDescription: core.StringPtr("IBM Cloud for Financial Services"),
 				ControlLibraryType:        core.StringPtr("custom"),
@@ -416,6 +425,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListControlLibraries(listControlLibrariesOptions *ListControlLibrariesOptions) with pagination`, func() {
 			listControlLibrariesOptions := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{
+				InstanceID:         core.StringPtr(instanceID),
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
 				Limit:              core.Int64Ptr(int64(50)),
@@ -445,6 +455,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListControlLibraries(listControlLibrariesOptions *ListControlLibrariesOptions) using ControlLibrariesPager`, func() {
 			listControlLibrariesOptions := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{
+				InstanceID:         core.StringPtr(instanceID),
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
 				Limit:              core.Int64Ptr(int64(50)),
@@ -487,6 +498,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ControlLibrariesID: &controlLibraryIdLink,
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
+				InstanceID:         core.StringPtr(instanceID),
 			}
 
 			controlLibrary, response, err := securityAndComplianceCenterApiService.GetControlLibrary(getControlLibraryOptions)
@@ -547,6 +559,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			replaceCustomControlLibraryOptions := &securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions{
+				InstanceID:                core.StringPtr(instanceID),
 				ControlLibrariesID:        &controlLibraryIdLink,
 				ID:                        core.StringPtr("testString"),
 				AccountID:                 core.StringPtr(accountID),
@@ -594,6 +607,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			createProfileOptions := &securityandcompliancecenterapiv3.CreateProfileOptions{
+				InstanceID:         core.StringPtr(instanceID),
 				ProfileName:        core.StringPtr("test_profile1"),
 				ProfileDescription: core.StringPtr("test_description1"),
 				ProfileType:        core.StringPtr("custom"),
@@ -621,6 +635,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listProfilesOptions := &securityandcompliancecenterapiv3.ListProfilesOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 				ProfileType:    core.StringPtr("custom"),
 				Start:          core.StringPtr("testString"),
@@ -650,6 +665,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listProfilesOptions := &securityandcompliancecenterapiv3.ListProfilesOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 				ProfileType:    core.StringPtr("custom"),
 			}
@@ -687,6 +703,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetProfile(getProfileOptions *GetProfileOptions)`, func() {
 			getProfileOptions := &securityandcompliancecenterapiv3.GetProfileOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -719,6 +736,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			replaceProfileOptions := &securityandcompliancecenterapiv3.ReplaceProfileOptions{
+				InstanceID:         core.StringPtr(instanceID),
 				ProfileID:          &profileIdLink,
 				ProfileName:        core.StringPtr("test_profile1"),
 				ProfileDescription: core.StringPtr("test_description1"),
@@ -742,6 +760,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListRules(listRulesOptions *ListRulesOptions)`, func() {
 			listRulesOptions := &securityandcompliancecenterapiv3.ListRulesOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				Type:           core.StringPtr("system_defined"),
@@ -798,6 +817,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			replaceRuleOptions := &securityandcompliancecenterapiv3.ReplaceRuleOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				RuleID:         &ruleIdLink,
 				IfMatch:        &eTagLink,
 				Description:    core.StringPtr("Example rule"),
@@ -868,6 +888,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			}
 
 			createAttachmentOptions := &securityandcompliancecenterapiv3.CreateAttachmentOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				ProfileID:      &profileIdLink,
 				Attachments:    []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel},
 				XCorrelationID: core.StringPtr("testString"),
@@ -893,6 +914,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 				Start:          core.StringPtr("testString"),
 			}
@@ -922,6 +944,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 			}
 
@@ -962,6 +985,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			attachmentItem, response, err := securityAndComplianceCenterApiService.GetProfileAttachment(getProfileAttachmentOptions)
@@ -1054,6 +1078,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				AttachmentID:   &createScanAttachmentID,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			scan, response, err := securityAndComplianceCenterApiService.CreateScan(createScanOptions)
@@ -1074,6 +1099,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listAttachmentsAccountOptions := &securityandcompliancecenterapiv3.ListAttachmentsAccountOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 				Start:          core.StringPtr("testString"),
 			}
@@ -1102,6 +1128,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listAttachmentsAccountOptions := &securityandcompliancecenterapiv3.ListAttachmentsAccountOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Limit:          core.Int64Ptr(int64(10)),
 			}
 
@@ -1140,6 +1167,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listReportsOptions := &securityandcompliancecenterapiv3.ListReportsOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				AttachmentID:   &attachmentIdForReportLink,
 				GroupID:        &groupIdForReportLink,
 				ProfileID:      &profileIdForReportLink,
@@ -1173,6 +1201,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			listReportsOptions := &securityandcompliancecenterapiv3.ListReportsOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				AttachmentID:   &attachmentIdForReportLink,
 				GroupID:        &groupIdForReportLink,
 				ProfileID:      &profileIdForReportLink,
@@ -1217,6 +1246,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			report, response, err := securityAndComplianceCenterApiService.GetReport(getReportOptions)
@@ -1235,6 +1265,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			reportSummary, response, err := securityAndComplianceCenterApiService.GetReportSummary(getReportSummaryOptions)
@@ -1253,6 +1284,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				ExcludeSummary: core.BoolPtr(true),
 			}
 
@@ -1272,6 +1304,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:           &reportIdForReportLink,
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
+				InstanceID:         core.StringPtr(instanceID),
 				ControlID:          core.StringPtr("testString"),
 				ControlName:        core.StringPtr("testString"),
 				ControlDescription: core.StringPtr("testString"),
@@ -1296,6 +1329,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				AssessmentID:   core.StringPtr("testString"),
 				ComponentID:    core.StringPtr("testString"),
 				TargetID:       core.StringPtr("testString"),
@@ -1330,6 +1364,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				Status:         core.StringPtr("failure"),
 				Limit:          core.Int64Ptr(int64(10)),
 			}
@@ -1369,6 +1404,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				ID:             core.StringPtr("testString"),
 				ResourceName:   core.StringPtr("testString"),
 				AccountID:      &accountIdForReportLink,
@@ -1404,6 +1440,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 				AccountID:      &accountIdForReportLink,
 				Status:         core.StringPtr("compliant"),
 				Sort:           core.StringPtr("account_id"),
@@ -1445,6 +1482,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:       &reportIdForReportLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			reportTags, response, err := securityAndComplianceCenterApiService.GetReportTags(getReportTagsOptions)
@@ -1463,6 +1501,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ReportID:         &reportIdForReportLink,
 				XCorrelationID:   core.StringPtr("testString"),
 				XRequestID:       core.StringPtr("testString"),
+				InstanceID:       core.StringPtr(instanceID),
 				ScanTimeDuration: core.Int64Ptr(int64(0)),
 			}
 
@@ -1526,6 +1565,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProviderTypeID: &providerTypeIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			providerTypeInstancesResponse, response, err := securityAndComplianceCenterApiService.ListProviderTypeInstances(listProviderTypeInstancesOptions)
@@ -1546,6 +1586,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				Attributes:     map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			providerTypeInstanceItem, response, err := securityAndComplianceCenterApiService.CreateProviderTypeInstance(createProviderTypeInstanceOptions)
@@ -1568,6 +1609,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProviderTypeInstanceID: &providerTypeInstanceIdLink,
 				XCorrelationID:         core.StringPtr("testString"),
 				XRequestID:             core.StringPtr("testString"),
+				InstanceID:             core.StringPtr(instanceID),
 			}
 
 			providerTypeInstanceItem, response, err := securityAndComplianceCenterApiService.GetProviderTypeInstance(getProviderTypeInstanceOptions)
@@ -1589,6 +1631,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				Attributes:             map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
 				XCorrelationID:         core.StringPtr("testString"),
 				XRequestID:             core.StringPtr("testString"),
+				InstanceID:             core.StringPtr(instanceID),
 			}
 
 			providerTypeInstanceItem, response, err := securityAndComplianceCenterApiService.UpdateProviderTypeInstance(updateProviderTypeInstanceOptions)
@@ -1606,6 +1649,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			getProviderTypesInstancesOptions := &securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions{
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			providerTypesInstancesResponse, response, err := securityAndComplianceCenterApiService.GetProviderTypesInstances(getProviderTypesInstancesOptions)
@@ -1625,6 +1669,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			attachmentItem, response, err := securityAndComplianceCenterApiService.DeleteProfileAttachment(deleteProfileAttachmentOptions)
@@ -1640,6 +1685,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`DeleteCustomProfile(deleteCustomProfileOptions *DeleteCustomProfileOptions)`, func() {
 			deleteCustomProfileOptions := &securityandcompliancecenterapiv3.DeleteCustomProfileOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				ProfileID:      &profileIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
@@ -1661,6 +1707,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ControlLibrariesID: &controlLibraryIdLink,
 				XCorrelationID:     core.StringPtr("testString"),
 				XRequestID:         core.StringPtr("testString"),
+				InstanceID:         core.StringPtr(instanceID),
 			}
 
 			controlLibraryDelete, response, err := securityAndComplianceCenterApiService.DeleteCustomControlLibrary(deleteCustomControlLibraryOptions)
@@ -1679,6 +1726,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				RuleID:         &ruleIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			response, err := securityAndComplianceCenterApiService.DeleteRule(deleteRuleOptions)
@@ -1697,6 +1745,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProviderTypeInstanceID: &providerTypeInstanceIdLink,
 				XCorrelationID:         core.StringPtr("testString"),
 				XRequestID:             core.StringPtr("testString"),
+				InstanceID:             core.StringPtr(instanceID),
 			}
 
 			response, err := securityAndComplianceCenterApiService.DeleteProviderTypeInstance(deleteProviderTypeInstanceOptions)

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -218,7 +218,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			createRuleOptions := &securityandcompliancecenterapiv3.CreateRuleOptions{
 				InstanceID:     core.StringPtr(instanceID),
-				Description:    core.StringPtr("Example rule"),
+				Description:    core.StringPtr("scc-go-sdk example rule"),
 				Target:         targetModel,
 				RequiredConfig: requiredConfigModel,
 				Type:           core.StringPtr("user_defined"),
@@ -398,8 +398,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			createCustomControlLibraryOptions := &securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions{
 				InstanceID:                core.StringPtr(instanceID),
-				ControlLibraryName:        core.StringPtr("IBM Cloud for Financial Services"),
-				ControlLibraryDescription: core.StringPtr("IBM Cloud for Financial Services"),
+				ControlLibraryName:        core.StringPtr("scc-go-sdk integrations control Library"),
+				ControlLibraryDescription: core.StringPtr("scc-go-sdk for Financial Services"),
 				ControlLibraryType:        core.StringPtr("custom"),
 				Controls:                  []securityandcompliancecenterapiv3.ControlsInControlLib{*controlsInControlLibModel},
 				ControlLibraryVersion:     core.StringPtr("1.0.0"),
@@ -563,7 +563,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ControlLibrariesID:        &controlLibraryIdLink,
 				ID:                        core.StringPtr("testString"),
 				AccountID:                 core.StringPtr(accountID),
-				ControlLibraryName:        core.StringPtr("IBM Cloud for Financial Services"),
+				ControlLibraryName:        core.StringPtr("scc-go-sdk control library"),
 				ControlLibraryDescription: core.StringPtr("IBM Cloud for Financial Services"),
 				ControlLibraryType:        core.StringPtr("custom"),
 				ControlLibraryVersion:     core.StringPtr("1.1.0"),
@@ -608,7 +608,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			createProfileOptions := &securityandcompliancecenterapiv3.CreateProfileOptions{
 				InstanceID:         core.StringPtr(instanceID),
-				ProfileName:        core.StringPtr("test_profile1"),
+				ProfileName:        core.StringPtr("scc-go-sdk integration test_profile1"),
 				ProfileDescription: core.StringPtr("test_description1"),
 				ProfileType:        core.StringPtr("custom"),
 				Controls:           []securityandcompliancecenterapiv3.ProfileControlsPrototype{*profileControlsPrototypeModel},
@@ -738,7 +738,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			replaceProfileOptions := &securityandcompliancecenterapiv3.ReplaceProfileOptions{
 				InstanceID:         core.StringPtr(instanceID),
 				ProfileID:          &profileIdLink,
-				ProfileName:        core.StringPtr("test_profile1"),
+				ProfileName:        core.StringPtr("scc-go-sdk test_profile"),
 				ProfileDescription: core.StringPtr("test_description1"),
 				ProfileType:        core.StringPtr("custom"),
 				Controls:           []securityandcompliancecenterapiv3.ProfileControlsPrototype{*profileControlsPrototypeModel},
@@ -878,7 +878,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			attachmentsPrototypeModel := &securityandcompliancecenterapiv3.AttachmentsPrototype{
 				ID:                   core.StringPtr("130003ea8bfa43c5aacea07a86da3000"),
-				Name:                 core.StringPtr("account-0d8c3805dfea40aa8ad02265a18eb12b"),
+				Name:                 core.StringPtr("scc-go-sdk integration attachment"),
 				Description:          core.StringPtr("Test description"),
 				Scope:                []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel},
 				Status:               core.StringPtr("enabled"),
@@ -1056,7 +1056,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				AttachmentParameters: []securityandcompliancecenterapiv3.AttachmentParameterPrototype{*attachmentParameterPrototypeModel},
 				LastScan:             lastScanModel,
 				NextScanTime:         CreateMockDateTime("2019-01-01T12:00:00.000Z"),
-				Name:                 core.StringPtr("account-0d8c3805dfea40aa8ad02265a18eb12b"),
+				Name:                 core.StringPtr("scc-go-sdk test profile_attachment"),
 				Description:          core.StringPtr("Test description"),
 				XCorrelationID:       core.StringPtr("testString"),
 				XRequestID:           core.StringPtr("testString"),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -65,7 +65,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 	Describe(`Service constructor tests using external config`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
-			var testEnvironment = map[string]string{
+			testEnvironment := map[string]string{
 				"SECURITY_AND_COMPLIANCE_CENTER_API_URL":       "https://securityandcompliancecenterapiv3/api",
 				"SECURITY_AND_COMPLIANCE_CENTER_API_AUTH_TYPE": "noauth",
 			}
@@ -119,7 +119,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
-			var testEnvironment = map[string]string{
+			testEnvironment := map[string]string{
 				"SECURITY_AND_COMPLIANCE_CENTER_API_URL":       "https://securityandcompliancecenterapiv3/api",
 				"SECURITY_AND_COMPLIANCE_CENTER_API_AUTH_TYPE": "someOtherAuth",
 			}
@@ -135,7 +135,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
-			var testEnvironment = map[string]string{
+			testEnvironment := map[string]string{
 				"SECURITY_AND_COMPLIANCE_CENTER_API_AUTH_TYPE": "NOAuth",
 			}
 
@@ -164,12 +164,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 	Describe(`Parameterized URL tests`, func() {
 		It(`Format parameterized URL with all default values`, func() {
 			constructedURL, err := securityandcompliancecenterapiv3.ConstructServiceURL(nil)
-			Expect(constructedURL).To(Equal("https://us-south.compliance.cloud.ibm.com/instances/instance_id/v3"))
 			Expect(constructedURL).ToNot(BeNil())
+			Expect(constructedURL).To(Equal("https://us-south.compliance.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 		})
 		It(`Return an error if a provided variable name is invalid`, func() {
-			var providedUrlVariables = map[string]string{
+			providedUrlVariables := map[string]string{
 				"invalid_variable_name": "value",
 			}
 			constructedURL, err := securityandcompliancecenterapiv3.ConstructServiceURL(providedUrlVariables)
@@ -178,7 +178,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetSettings(getSettingsOptions *GetSettingsOptions) - Operation response error`, func() {
-		getSettingsPath := "/settings"
+		getSettingsPath := "/instances/testInstance/v3/settings"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -206,6 +206,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetSettingsOptions model
 				getSettingsOptionsModel := new(securityandcompliancecenterapiv3.GetSettingsOptions)
+				getSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.XRequestID = core.StringPtr("testString")
 				getSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -228,7 +229,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetSettings(getSettingsOptions *GetSettingsOptions)`, func() {
-		getSettingsPath := "/settings"
+		getSettingsPath := "/instances/testInstance/v3/settings"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -262,6 +263,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetSettingsOptions model
 				getSettingsOptionsModel := new(securityandcompliancecenterapiv3.GetSettingsOptions)
+				getSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.XRequestID = core.StringPtr("testString")
 				getSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -326,6 +328,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetSettingsOptions model
 				getSettingsOptionsModel := new(securityandcompliancecenterapiv3.GetSettingsOptions)
+				getSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.XRequestID = core.StringPtr("testString")
 				getSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -335,7 +338,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetSettings with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -347,6 +349,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetSettingsOptions model
 				getSettingsOptionsModel := new(securityandcompliancecenterapiv3.GetSettingsOptions)
+				getSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.XRequestID = core.StringPtr("testString")
 				getSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -382,6 +385,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetSettingsOptions model
 				getSettingsOptionsModel := new(securityandcompliancecenterapiv3.GetSettingsOptions)
+				getSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.XRequestID = core.StringPtr("testString")
 				getSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -400,7 +404,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`UpdateSettings(updateSettingsOptions *UpdateSettingsOptions) - Operation response error`, func() {
-		updateSettingsPath := "/settings"
+		updateSettingsPath := "/instances/testInstance/v3/settings"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -444,6 +448,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateSettingsOptions model
 				updateSettingsOptionsModel := new(securityandcompliancecenterapiv3.UpdateSettingsOptions)
+				updateSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateSettingsOptionsModel.EventNotifications = eventNotificationsModel
 				updateSettingsOptionsModel.ObjectStorage = objectStorageModel
 				updateSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -468,7 +473,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`UpdateSettings(updateSettingsOptions *UpdateSettingsOptions)`, func() {
-		updateSettingsPath := "/settings"
+		updateSettingsPath := "/instances/testInstance/v3/settings"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -534,6 +539,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateSettingsOptions model
 				updateSettingsOptionsModel := new(securityandcompliancecenterapiv3.UpdateSettingsOptions)
+				updateSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateSettingsOptionsModel.EventNotifications = eventNotificationsModel
 				updateSettingsOptionsModel.ObjectStorage = objectStorageModel
 				updateSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -632,6 +638,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateSettingsOptions model
 				updateSettingsOptionsModel := new(securityandcompliancecenterapiv3.UpdateSettingsOptions)
+				updateSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateSettingsOptionsModel.EventNotifications = eventNotificationsModel
 				updateSettingsOptionsModel.ObjectStorage = objectStorageModel
 				updateSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -643,7 +650,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke UpdateSettings with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -671,6 +677,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateSettingsOptions model
 				updateSettingsOptionsModel := new(securityandcompliancecenterapiv3.UpdateSettingsOptions)
+				updateSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateSettingsOptionsModel.EventNotifications = eventNotificationsModel
 				updateSettingsOptionsModel.ObjectStorage = objectStorageModel
 				updateSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -724,6 +731,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateSettingsOptions model
 				updateSettingsOptionsModel := new(securityandcompliancecenterapiv3.UpdateSettingsOptions)
+				updateSettingsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateSettingsOptionsModel.EventNotifications = eventNotificationsModel
 				updateSettingsOptionsModel.ObjectStorage = objectStorageModel
 				updateSettingsOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
@@ -744,7 +752,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`PostTestEvent(postTestEventOptions *PostTestEventOptions) - Operation response error`, func() {
-		postTestEventPath := "/test_event"
+		postTestEventPath := "/instances/testInstance/v3/test_event"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -772,6 +780,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the PostTestEventOptions model
 				postTestEventOptionsModel := new(securityandcompliancecenterapiv3.PostTestEventOptions)
+				postTestEventOptionsModel.InstanceID = core.StringPtr("testInstance")
 				postTestEventOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.XRequestID = core.StringPtr("testString")
 				postTestEventOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -794,7 +803,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`PostTestEvent(postTestEventOptions *PostTestEventOptions)`, func() {
-		postTestEventPath := "/test_event"
+		postTestEventPath := "/instances/testInstance/v3/test_event"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -828,6 +837,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the PostTestEventOptions model
 				postTestEventOptionsModel := new(securityandcompliancecenterapiv3.PostTestEventOptions)
+				postTestEventOptionsModel.InstanceID = core.StringPtr("testInstance")
 				postTestEventOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.XRequestID = core.StringPtr("testString")
 				postTestEventOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -892,6 +902,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the PostTestEventOptions model
 				postTestEventOptionsModel := new(securityandcompliancecenterapiv3.PostTestEventOptions)
+				postTestEventOptionsModel.InstanceID = core.StringPtr("testInstance")
 				postTestEventOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.XRequestID = core.StringPtr("testString")
 				postTestEventOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -901,7 +912,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke PostTestEvent with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -913,6 +923,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the PostTestEventOptions model
 				postTestEventOptionsModel := new(securityandcompliancecenterapiv3.PostTestEventOptions)
+				postTestEventOptionsModel.InstanceID = core.StringPtr("testInstance")
 				postTestEventOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.XRequestID = core.StringPtr("testString")
 				postTestEventOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -948,6 +959,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the PostTestEventOptions model
 				postTestEventOptionsModel := new(securityandcompliancecenterapiv3.PostTestEventOptions)
+				postTestEventOptionsModel.InstanceID = core.StringPtr("testInstance")
 				postTestEventOptionsModel.XCorrelationID = core.StringPtr("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.XRequestID = core.StringPtr("testString")
 				postTestEventOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -966,7 +978,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListControlLibraries(listControlLibrariesOptions *ListControlLibrariesOptions) - Operation response error`, func() {
-		listControlLibrariesPath := "/control_libraries"
+		listControlLibrariesPath := "/instances/testInstance/v3/control_libraries"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -997,6 +1009,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListControlLibrariesOptions model
 				listControlLibrariesOptionsModel := new(securityandcompliancecenterapiv3.ListControlLibrariesOptions)
+				listControlLibrariesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listControlLibrariesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.XRequestID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.Limit = core.Int64Ptr(int64(50))
@@ -1022,7 +1035,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListControlLibraries(listControlLibrariesOptions *ListControlLibrariesOptions)`, func() {
-		listControlLibrariesPath := "/control_libraries"
+		listControlLibrariesPath := "/instances/testInstance/v3/control_libraries"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1059,6 +1072,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListControlLibrariesOptions model
 				listControlLibrariesOptionsModel := new(securityandcompliancecenterapiv3.ListControlLibrariesOptions)
+				listControlLibrariesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listControlLibrariesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.XRequestID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.Limit = core.Int64Ptr(int64(50))
@@ -1129,6 +1143,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListControlLibrariesOptions model
 				listControlLibrariesOptionsModel := new(securityandcompliancecenterapiv3.ListControlLibrariesOptions)
+				listControlLibrariesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listControlLibrariesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.XRequestID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.Limit = core.Int64Ptr(int64(50))
@@ -1141,7 +1156,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListControlLibraries with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -1153,6 +1167,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListControlLibrariesOptions model
 				listControlLibrariesOptionsModel := new(securityandcompliancecenterapiv3.ListControlLibrariesOptions)
+				listControlLibrariesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listControlLibrariesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.XRequestID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.Limit = core.Int64Ptr(int64(50))
@@ -1191,6 +1206,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListControlLibrariesOptions model
 				listControlLibrariesOptionsModel := new(securityandcompliancecenterapiv3.ListControlLibrariesOptions)
+				listControlLibrariesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listControlLibrariesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.XRequestID = core.StringPtr("testString")
 				listControlLibrariesOptionsModel.Limit = core.Int64Ptr(int64(50))
@@ -1261,6 +1277,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listControlLibrariesOptionsModel := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{
+					InstanceID:         core.StringPtr("testInstance"),
 					XCorrelationID:     core.StringPtr("testString"),
 					XRequestID:         core.StringPtr("testString"),
 					Limit:              core.Int64Ptr(int64(50)),
@@ -1289,6 +1306,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listControlLibrariesOptionsModel := &securityandcompliancecenterapiv3.ListControlLibrariesOptions{
+					InstanceID:         core.StringPtr("testInstance"),
 					XCorrelationID:     core.StringPtr("testString"),
 					XRequestID:         core.StringPtr("testString"),
 					Limit:              core.Int64Ptr(int64(50)),
@@ -1307,7 +1325,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateCustomControlLibrary(createCustomControlLibraryOptions *CreateCustomControlLibraryOptions) - Operation response error`, func() {
-		createCustomControlLibraryPath := "/control_libraries"
+		createCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1380,6 +1398,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
 				createCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions)
+				createCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createCustomControlLibraryOptionsModel.ControlLibraryName = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryDescription = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryType = core.StringPtr("custom")
@@ -1410,7 +1429,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateCustomControlLibrary(createCustomControlLibraryOptions *CreateCustomControlLibraryOptions)`, func() {
-		createCustomControlLibraryPath := "/control_libraries"
+		createCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1505,6 +1524,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
 				createCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions)
+				createCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createCustomControlLibraryOptionsModel.ControlLibraryName = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryDescription = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryType = core.StringPtr("custom")
@@ -1638,6 +1658,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
 				createCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions)
+				createCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createCustomControlLibraryOptionsModel.ControlLibraryName = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryDescription = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryType = core.StringPtr("custom")
@@ -1655,7 +1676,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateCustomControlLibrary with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -1712,6 +1732,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
 				createCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions)
+				createCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createCustomControlLibraryOptionsModel.ControlLibraryName = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryDescription = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryType = core.StringPtr("custom")
@@ -1807,6 +1828,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
 				createCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.CreateCustomControlLibraryOptions)
+				createCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createCustomControlLibraryOptionsModel.ControlLibraryName = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryDescription = core.StringPtr("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.ControlLibraryType = core.StringPtr("custom")
@@ -1833,7 +1855,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteCustomControlLibrary(deleteCustomControlLibraryOptions *DeleteCustomControlLibraryOptions) - Operation response error`, func() {
-		deleteCustomControlLibraryPath := "/control_libraries/testString"
+		deleteCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1861,6 +1883,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
 				deleteCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions)
+				deleteCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -1884,7 +1907,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteCustomControlLibrary(deleteCustomControlLibraryOptions *DeleteCustomControlLibraryOptions)`, func() {
-		deleteCustomControlLibraryPath := "/control_libraries/testString"
+		deleteCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1918,6 +1941,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
 				deleteCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions)
+				deleteCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -1983,6 +2007,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
 				deleteCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions)
+				deleteCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -1993,7 +2018,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke DeleteCustomControlLibrary with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -2005,6 +2029,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
 				deleteCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions)
+				deleteCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2048,6 +2073,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
 				deleteCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomControlLibraryOptions)
+				deleteCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2067,7 +2093,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetControlLibrary(getControlLibraryOptions *GetControlLibraryOptions) - Operation response error`, func() {
-		getControlLibraryPath := "/control_libraries/testString"
+		getControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2095,6 +2121,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetControlLibraryOptions model
 				getControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.GetControlLibraryOptions)
+				getControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2118,7 +2145,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetControlLibrary(getControlLibraryOptions *GetControlLibraryOptions)`, func() {
-		getControlLibraryPath := "/control_libraries/testString"
+		getControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2152,6 +2179,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetControlLibraryOptions model
 				getControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.GetControlLibraryOptions)
+				getControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2217,6 +2245,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetControlLibraryOptions model
 				getControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.GetControlLibraryOptions)
+				getControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2227,7 +2256,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetControlLibrary with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -2239,6 +2267,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetControlLibraryOptions model
 				getControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.GetControlLibraryOptions)
+				getControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2282,6 +2311,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetControlLibraryOptions model
 				getControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.GetControlLibraryOptions)
+				getControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getControlLibraryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -2301,7 +2331,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceCustomControlLibrary(replaceCustomControlLibraryOptions *ReplaceCustomControlLibraryOptions) - Operation response error`, func() {
-		replaceCustomControlLibraryPath := "/control_libraries/testString"
+		replaceCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2374,6 +2404,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
 				replaceCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions)
+				replaceCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.ID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.AccountID = core.StringPtr("testString")
@@ -2413,7 +2444,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceCustomControlLibrary(replaceCustomControlLibraryOptions *ReplaceCustomControlLibraryOptions)`, func() {
-		replaceCustomControlLibraryPath := "/control_libraries/testString"
+		replaceCustomControlLibraryPath := "/instances/testInstance/v3/control_libraries/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2508,6 +2539,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
 				replaceCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions)
+				replaceCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.ID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.AccountID = core.StringPtr("testString")
@@ -2650,6 +2682,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
 				replaceCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions)
+				replaceCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.ID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.AccountID = core.StringPtr("testString")
@@ -2676,7 +2709,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ReplaceCustomControlLibrary with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -2733,6 +2765,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
 				replaceCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions)
+				replaceCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.ID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.AccountID = core.StringPtr("testString")
@@ -2837,6 +2870,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
 				replaceCustomControlLibraryOptionsModel := new(securityandcompliancecenterapiv3.ReplaceCustomControlLibraryOptions)
+				replaceCustomControlLibraryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceCustomControlLibraryOptionsModel.ControlLibrariesID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.ID = core.StringPtr("testString")
 				replaceCustomControlLibraryOptionsModel.AccountID = core.StringPtr("testString")
@@ -2872,7 +2906,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProfiles(listProfilesOptions *ListProfilesOptions) - Operation response error`, func() {
-		listProfilesPath := "/profiles"
+		listProfilesPath := "/instances/testInstance/v3/profiles"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2903,6 +2937,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProfilesOptions model
 				listProfilesOptionsModel := new(securityandcompliancecenterapiv3.ListProfilesOptions)
+				listProfilesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProfilesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProfilesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProfilesOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -2928,7 +2963,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProfiles(listProfilesOptions *ListProfilesOptions)`, func() {
-		listProfilesPath := "/profiles"
+		listProfilesPath := "/instances/testInstance/v3/profiles"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2965,6 +3000,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProfilesOptions model
 				listProfilesOptionsModel := new(securityandcompliancecenterapiv3.ListProfilesOptions)
+				listProfilesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProfilesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProfilesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProfilesOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -3035,6 +3071,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProfilesOptions model
 				listProfilesOptionsModel := new(securityandcompliancecenterapiv3.ListProfilesOptions)
+				listProfilesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProfilesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProfilesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProfilesOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -3047,7 +3084,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListProfiles with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -3059,6 +3095,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProfilesOptions model
 				listProfilesOptionsModel := new(securityandcompliancecenterapiv3.ListProfilesOptions)
+				listProfilesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProfilesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProfilesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProfilesOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -3097,6 +3134,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProfilesOptions model
 				listProfilesOptionsModel := new(securityandcompliancecenterapiv3.ListProfilesOptions)
+				listProfilesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProfilesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProfilesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProfilesOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -3167,6 +3205,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listProfilesOptionsModel := &securityandcompliancecenterapiv3.ListProfilesOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -3195,6 +3234,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listProfilesOptionsModel := &securityandcompliancecenterapiv3.ListProfilesOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -3213,7 +3253,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateProfile(createProfileOptions *CreateProfileOptions) - Operation response error`, func() {
-		createProfilePath := "/profiles"
+		createProfilePath := "/instances/testInstance/v3/profiles"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3255,6 +3295,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProfileOptions model
 				createProfileOptionsModel := new(securityandcompliancecenterapiv3.CreateProfileOptions)
+				createProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				createProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				createProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -3282,7 +3323,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateProfile(createProfileOptions *CreateProfileOptions)`, func() {
-		createProfilePath := "/profiles"
+		createProfilePath := "/instances/testInstance/v3/profiles"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3346,6 +3387,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProfileOptions model
 				createProfileOptionsModel := new(securityandcompliancecenterapiv3.CreateProfileOptions)
+				createProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				createProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				createProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -3445,6 +3487,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProfileOptions model
 				createProfileOptionsModel := new(securityandcompliancecenterapiv3.CreateProfileOptions)
+				createProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				createProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				createProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -3459,7 +3502,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateProfile with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -3485,6 +3527,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProfileOptions model
 				createProfileOptionsModel := new(securityandcompliancecenterapiv3.CreateProfileOptions)
+				createProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				createProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				createProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -3546,6 +3589,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProfileOptions model
 				createProfileOptionsModel := new(securityandcompliancecenterapiv3.CreateProfileOptions)
+				createProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				createProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
 				createProfileOptionsModel.ProfileType = core.StringPtr("custom")
@@ -3569,7 +3613,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteCustomProfile(deleteCustomProfileOptions *DeleteCustomProfileOptions) - Operation response error`, func() {
-		deleteCustomProfilePath := "/profiles/testString"
+		deleteCustomProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3597,6 +3641,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
+				deleteCustomProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3620,7 +3665,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteCustomProfile(deleteCustomProfileOptions *DeleteCustomProfileOptions)`, func() {
-		deleteCustomProfilePath := "/profiles/testString"
+		deleteCustomProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3654,6 +3699,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
+				deleteCustomProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3719,6 +3765,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
+				deleteCustomProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3729,7 +3776,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke DeleteCustomProfile with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -3741,6 +3787,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
+				deleteCustomProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3784,6 +3831,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteCustomProfileOptions model
 				deleteCustomProfileOptionsModel := new(securityandcompliancecenterapiv3.DeleteCustomProfileOptions)
+				deleteCustomProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteCustomProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteCustomProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3803,7 +3851,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProfile(getProfileOptions *GetProfileOptions) - Operation response error`, func() {
-		getProfilePath := "/profiles/testString"
+		getProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3831,6 +3879,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
+				getProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3854,7 +3903,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProfile(getProfileOptions *GetProfileOptions)`, func() {
-		getProfilePath := "/profiles/testString"
+		getProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3888,6 +3937,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
+				getProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3953,6 +4003,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
+				getProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -3963,7 +4014,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetProfile with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -3975,6 +4025,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
+				getProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -4018,6 +4069,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(securityandcompliancecenterapiv3.GetProfileOptions)
+				getProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProfileOptionsModel.XRequestID = core.StringPtr("testString")
@@ -4037,7 +4089,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceProfile(replaceProfileOptions *ReplaceProfileOptions) - Operation response error`, func() {
-		replaceProfilePath := "/profiles/testString"
+		replaceProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4079,6 +4131,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
+				replaceProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
@@ -4107,7 +4160,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceProfile(replaceProfileOptions *ReplaceProfileOptions)`, func() {
-		replaceProfilePath := "/profiles/testString"
+		replaceProfilePath := "/instances/testInstance/v3/profiles/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4171,6 +4224,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
+				replaceProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
@@ -4271,6 +4325,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
+				replaceProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
@@ -4286,7 +4341,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ReplaceProfile with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -4312,6 +4366,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
+				replaceProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
@@ -4374,6 +4429,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileOptions model
 				replaceProfileOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileOptions)
+				replaceProfileOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileOptionsModel.ProfileName = core.StringPtr("test_profile1")
 				replaceProfileOptionsModel.ProfileDescription = core.StringPtr("test_description1")
@@ -4398,7 +4454,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListRules(listRulesOptions *ListRulesOptions) - Operation response error`, func() {
-		listRulesPath := "/rules"
+		listRulesPath := "/instances/testInstance/v3/rules"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4429,6 +4485,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(securityandcompliancecenterapiv3.ListRulesOptions)
+				listRulesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.XRequestID = core.StringPtr("testString")
 				listRulesOptionsModel.Type = core.StringPtr("system_defined")
@@ -4454,7 +4511,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListRules(listRulesOptions *ListRulesOptions)`, func() {
-		listRulesPath := "/rules"
+		listRulesPath := "/instances/testInstance/v3/rules"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4491,6 +4548,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(securityandcompliancecenterapiv3.ListRulesOptions)
+				listRulesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.XRequestID = core.StringPtr("testString")
 				listRulesOptionsModel.Type = core.StringPtr("system_defined")
@@ -4561,6 +4619,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(securityandcompliancecenterapiv3.ListRulesOptions)
+				listRulesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.XRequestID = core.StringPtr("testString")
 				listRulesOptionsModel.Type = core.StringPtr("system_defined")
@@ -4573,7 +4632,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListRules with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -4585,6 +4643,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(securityandcompliancecenterapiv3.ListRulesOptions)
+				listRulesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.XRequestID = core.StringPtr("testString")
 				listRulesOptionsModel.Type = core.StringPtr("system_defined")
@@ -4623,6 +4682,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(securityandcompliancecenterapiv3.ListRulesOptions)
+				listRulesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.XRequestID = core.StringPtr("testString")
 				listRulesOptionsModel.Type = core.StringPtr("system_defined")
@@ -4644,7 +4704,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateRule(createRuleOptions *CreateRuleOptions) - Operation response error`, func() {
-		createRulePath := "/rules"
+		createRulePath := "/instances/testInstance/v3/rules"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4708,6 +4768,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsModel := new(securityandcompliancecenterapiv3.CreateRuleOptions)
+				createRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createRuleOptionsModel.Description = core.StringPtr("Example rule")
 				createRuleOptionsModel.Target = targetModel
 				createRuleOptionsModel.RequiredConfig = requiredConfigModel
@@ -4737,7 +4798,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateRule(createRuleOptions *CreateRuleOptions)`, func() {
-		createRulePath := "/rules"
+		createRulePath := "/instances/testInstance/v3/rules"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4823,6 +4884,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsModel := new(securityandcompliancecenterapiv3.CreateRuleOptions)
+				createRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createRuleOptionsModel.Description = core.StringPtr("Example rule")
 				createRuleOptionsModel.Target = targetModel
 				createRuleOptionsModel.RequiredConfig = requiredConfigModel
@@ -4946,6 +5008,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsModel := new(securityandcompliancecenterapiv3.CreateRuleOptions)
+				createRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createRuleOptionsModel.Description = core.StringPtr("Example rule")
 				createRuleOptionsModel.Target = targetModel
 				createRuleOptionsModel.RequiredConfig = requiredConfigModel
@@ -4962,7 +5025,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateRule with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -5010,6 +5072,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsModel := new(securityandcompliancecenterapiv3.CreateRuleOptions)
+				createRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createRuleOptionsModel.Description = core.StringPtr("Example rule")
 				createRuleOptionsModel.Target = targetModel
 				createRuleOptionsModel.RequiredConfig = requiredConfigModel
@@ -5095,6 +5158,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsModel := new(securityandcompliancecenterapiv3.CreateRuleOptions)
+				createRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createRuleOptionsModel.Description = core.StringPtr("Example rule")
 				createRuleOptionsModel.Target = targetModel
 				createRuleOptionsModel.RequiredConfig = requiredConfigModel
@@ -5120,7 +5184,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteRule(deleteRuleOptions *DeleteRuleOptions)`, func() {
-		deleteRulePath := "/rules/testString"
+		deleteRulePath := "/instances/testInstance/v3/rules/testString"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5152,6 +5216,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteRuleOptions model
 				deleteRuleOptionsModel := new(securityandcompliancecenterapiv3.DeleteRuleOptions)
+				deleteRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteRuleOptionsModel.RuleID = core.StringPtr("testString")
 				deleteRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5172,6 +5237,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteRuleOptions model
 				deleteRuleOptionsModel := new(securityandcompliancecenterapiv3.DeleteRuleOptions)
+				deleteRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteRuleOptionsModel.RuleID = core.StringPtr("testString")
 				deleteRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5196,7 +5262,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetRule(getRuleOptions *GetRuleOptions) - Operation response error`, func() {
-		getRulePath := "/rules/testString"
+		getRulePath := "/instances/testInstance/v3/rules/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5224,6 +5290,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(securityandcompliancecenterapiv3.GetRuleOptions)
+				getRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
 				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5247,7 +5314,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetRule(getRuleOptions *GetRuleOptions)`, func() {
-		getRulePath := "/rules/testString"
+		getRulePath := "/instances/testInstance/v3/rules/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5281,6 +5348,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(securityandcompliancecenterapiv3.GetRuleOptions)
+				getRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
 				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5346,6 +5414,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(securityandcompliancecenterapiv3.GetRuleOptions)
+				getRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
 				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5356,7 +5425,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetRule with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -5368,6 +5436,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(securityandcompliancecenterapiv3.GetRuleOptions)
+				getRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
 				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5411,6 +5480,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(securityandcompliancecenterapiv3.GetRuleOptions)
+				getRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
 				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5430,7 +5500,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceRule(replaceRuleOptions *ReplaceRuleOptions) - Operation response error`, func() {
-		replaceRulePath := "/rules/testString"
+		replaceRulePath := "/instances/testInstance/v3/rules/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5496,6 +5566,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceRuleOptions model
 				replaceRuleOptionsModel := new(securityandcompliancecenterapiv3.ReplaceRuleOptions)
+				replaceRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceRuleOptionsModel.RuleID = core.StringPtr("testString")
 				replaceRuleOptionsModel.IfMatch = core.StringPtr("testString")
 				replaceRuleOptionsModel.Description = core.StringPtr("Example rule")
@@ -5527,7 +5598,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceRule(replaceRuleOptions *ReplaceRuleOptions)`, func() {
-		replaceRulePath := "/rules/testString"
+		replaceRulePath := "/instances/testInstance/v3/rules/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5615,6 +5686,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceRuleOptions model
 				replaceRuleOptionsModel := new(securityandcompliancecenterapiv3.ReplaceRuleOptions)
+				replaceRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceRuleOptionsModel.RuleID = core.StringPtr("testString")
 				replaceRuleOptionsModel.IfMatch = core.StringPtr("testString")
 				replaceRuleOptionsModel.Description = core.StringPtr("Example rule")
@@ -5742,6 +5814,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceRuleOptions model
 				replaceRuleOptionsModel := new(securityandcompliancecenterapiv3.ReplaceRuleOptions)
+				replaceRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceRuleOptionsModel.RuleID = core.StringPtr("testString")
 				replaceRuleOptionsModel.IfMatch = core.StringPtr("testString")
 				replaceRuleOptionsModel.Description = core.StringPtr("Example rule")
@@ -5760,7 +5833,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ReplaceRule with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -5808,6 +5880,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceRuleOptions model
 				replaceRuleOptionsModel := new(securityandcompliancecenterapiv3.ReplaceRuleOptions)
+				replaceRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceRuleOptionsModel.RuleID = core.StringPtr("testString")
 				replaceRuleOptionsModel.IfMatch = core.StringPtr("testString")
 				replaceRuleOptionsModel.Description = core.StringPtr("Example rule")
@@ -5895,6 +5968,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceRuleOptions model
 				replaceRuleOptionsModel := new(securityandcompliancecenterapiv3.ReplaceRuleOptions)
+				replaceRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceRuleOptionsModel.RuleID = core.StringPtr("testString")
 				replaceRuleOptionsModel.IfMatch = core.StringPtr("testString")
 				replaceRuleOptionsModel.Description = core.StringPtr("Example rule")
@@ -5922,7 +5996,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListAttachments(listAttachmentsOptions *ListAttachmentsOptions) - Operation response error`, func() {
-		listAttachmentsPath := "/profiles/testString/attachments"
+		listAttachmentsPath := "/instances/testInstance/v3/profiles/testString/attachments"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -5952,6 +6026,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
+				listAttachmentsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -5977,7 +6052,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListAttachments(listAttachmentsOptions *ListAttachmentsOptions)`, func() {
-		listAttachmentsPath := "/profiles/testString/attachments"
+		listAttachmentsPath := "/instances/testInstance/v3/profiles/testString/attachments"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -6013,6 +6088,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
+				listAttachmentsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -6082,6 +6158,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
+				listAttachmentsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -6094,7 +6171,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListAttachments with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -6106,6 +6182,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
+				listAttachmentsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -6151,6 +6228,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsOptions model
 				listAttachmentsOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsOptions)
+				listAttachmentsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsOptionsModel.ProfileID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -6221,6 +6299,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ProfileID:      core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -6249,6 +6328,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ProfileID:      core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -6267,7 +6347,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateAttachment(createAttachmentOptions *CreateAttachmentOptions) - Operation response error`, func() {
-		createAttachmentPath := "/profiles/testString/attachments"
+		createAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -6335,6 +6415,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
+				createAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
@@ -6360,7 +6441,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateAttachment(createAttachmentOptions *CreateAttachmentOptions)`, func() {
-		createAttachmentPath := "/profiles/testString/attachments"
+		createAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -6450,6 +6531,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
+				createAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
@@ -6573,6 +6655,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
+				createAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
@@ -6585,7 +6668,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateAttachment with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -6637,6 +6719,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
+				createAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
@@ -6722,6 +6805,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateAttachmentOptions model
 				createAttachmentOptionsModel := new(securityandcompliancecenterapiv3.CreateAttachmentOptions)
+				createAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				createAttachmentOptionsModel.Attachments = []securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel}
 				createAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
@@ -6743,7 +6827,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteProfileAttachment(deleteProfileAttachmentOptions *DeleteProfileAttachmentOptions) - Operation response error`, func() {
-		deleteProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		deleteProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -6771,6 +6855,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
+				deleteProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6795,7 +6880,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteProfileAttachment(deleteProfileAttachmentOptions *DeleteProfileAttachmentOptions)`, func() {
-		deleteProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		deleteProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -6829,6 +6914,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
+				deleteProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6895,6 +6981,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
+				deleteProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6906,7 +6993,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke DeleteProfileAttachment with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -6918,6 +7004,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
+				deleteProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6962,6 +7049,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProfileAttachmentOptions model
 				deleteProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.DeleteProfileAttachmentOptions)
+				deleteProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				deleteProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -6982,7 +7070,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProfileAttachment(getProfileAttachmentOptions *GetProfileAttachmentOptions) - Operation response error`, func() {
-		getProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		getProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7010,6 +7098,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
+				getProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -7034,7 +7123,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProfileAttachment(getProfileAttachmentOptions *GetProfileAttachmentOptions)`, func() {
-		getProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		getProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7068,6 +7157,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
+				getProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -7134,6 +7224,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
+				getProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -7145,7 +7236,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetProfileAttachment with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -7157,6 +7247,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
+				getProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -7201,6 +7292,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProfileAttachmentOptions model
 				getProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.GetProfileAttachmentOptions)
+				getProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				getProfileAttachmentOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -7221,7 +7313,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceProfileAttachment(replaceProfileAttachmentOptions *ReplaceProfileAttachmentOptions) - Operation response error`, func() {
-		replaceProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		replaceProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7284,12 +7376,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
+				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.Scope = []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel}
 				replaceProfileAttachmentOptionsModel.CreatedOn = CreateMockDateTime("2019-01-01T12:00:00.000Z")
 				replaceProfileAttachmentOptionsModel.CreatedBy = core.StringPtr("testString")
@@ -7325,7 +7417,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ReplaceProfileAttachment(replaceProfileAttachmentOptions *ReplaceProfileAttachmentOptions)`, func() {
-		replaceProfileAttachmentPath := "/profiles/testString/attachments/testString"
+		replaceProfileAttachmentPath := "/instances/testInstance/v3/profiles/testString/attachments/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7410,12 +7502,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
 				replaceProfileAttachmentOptionsModel := new(securityandcompliancecenterapiv3.ReplaceProfileAttachmentOptions)
+				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileAttachmentOptionsModel.AttachmentID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.Scope = []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel}
 				replaceProfileAttachmentOptionsModel.CreatedOn = CreateMockDateTime("2019-01-01T12:00:00.000Z")
 				replaceProfileAttachmentOptionsModel.CreatedBy = core.StringPtr("testString")
@@ -7549,7 +7641,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileAttachmentOptionsModel.Scope = []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel}
 				replaceProfileAttachmentOptionsModel.CreatedOn = CreateMockDateTime("2019-01-01T12:00:00.000Z")
 				replaceProfileAttachmentOptionsModel.CreatedBy = core.StringPtr("testString")
@@ -7572,7 +7664,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ReplaceProfileAttachment with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -7624,7 +7715,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileAttachmentOptionsModel.Scope = []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel}
 				replaceProfileAttachmentOptionsModel.CreatedOn = CreateMockDateTime("2019-01-01T12:00:00.000Z")
 				replaceProfileAttachmentOptionsModel.CreatedBy = core.StringPtr("testString")
@@ -7720,7 +7811,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				replaceProfileAttachmentOptionsModel.ID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.ProfileID = core.StringPtr("testString")
 				replaceProfileAttachmentOptionsModel.AccountID = core.StringPtr("testString")
-				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testString")
+				replaceProfileAttachmentOptionsModel.InstanceID = core.StringPtr("testInstance")
 				replaceProfileAttachmentOptionsModel.Scope = []securityandcompliancecenterapiv3.MultiCloudScope{*multiCloudScopeModel}
 				replaceProfileAttachmentOptionsModel.CreatedOn = CreateMockDateTime("2019-01-01T12:00:00.000Z")
 				replaceProfileAttachmentOptionsModel.CreatedBy = core.StringPtr("testString")
@@ -7752,7 +7843,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateScan(createScanOptions *CreateScanOptions) - Operation response error`, func() {
-		createScanPath := "/scans"
+		createScanPath := "/instances/testInstance/v3/scans"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7780,6 +7871,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateScanOptions model
 				createScanOptionsModel := new(securityandcompliancecenterapiv3.CreateScanOptions)
+				createScanOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createScanOptionsModel.AttachmentID = core.StringPtr("testString")
 				createScanOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createScanOptionsModel.XRequestID = core.StringPtr("testString")
@@ -7803,7 +7895,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateScan(createScanOptions *CreateScanOptions)`, func() {
-		createScanPath := "/scans"
+		createScanPath := "/instances/testInstance/v3/scans"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -7853,6 +7945,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateScanOptions model
 				createScanOptionsModel := new(securityandcompliancecenterapiv3.CreateScanOptions)
+				createScanOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createScanOptionsModel.AttachmentID = core.StringPtr("testString")
 				createScanOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createScanOptionsModel.XRequestID = core.StringPtr("testString")
@@ -7934,6 +8027,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateScanOptions model
 				createScanOptionsModel := new(securityandcompliancecenterapiv3.CreateScanOptions)
+				createScanOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createScanOptionsModel.AttachmentID = core.StringPtr("testString")
 				createScanOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createScanOptionsModel.XRequestID = core.StringPtr("testString")
@@ -7944,7 +8038,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateScan with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -7956,6 +8049,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateScanOptions model
 				createScanOptionsModel := new(securityandcompliancecenterapiv3.CreateScanOptions)
+				createScanOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createScanOptionsModel.AttachmentID = core.StringPtr("testString")
 				createScanOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createScanOptionsModel.XRequestID = core.StringPtr("testString")
@@ -7999,6 +8093,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateScanOptions model
 				createScanOptionsModel := new(securityandcompliancecenterapiv3.CreateScanOptions)
+				createScanOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createScanOptionsModel.AttachmentID = core.StringPtr("testString")
 				createScanOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createScanOptionsModel.XRequestID = core.StringPtr("testString")
@@ -8018,7 +8113,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListAttachmentsAccount(listAttachmentsAccountOptions *ListAttachmentsAccountOptions) - Operation response error`, func() {
-		listAttachmentsAccountPath := "/attachments"
+		listAttachmentsAccountPath := "/instances/testInstance/v3/attachments"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8048,6 +8143,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsAccountOptions model
 				listAttachmentsAccountOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsAccountOptions)
+				listAttachmentsAccountOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsAccountOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -8072,7 +8168,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListAttachmentsAccount(listAttachmentsAccountOptions *ListAttachmentsAccountOptions)`, func() {
-		listAttachmentsAccountPath := "/attachments"
+		listAttachmentsAccountPath := "/instances/testInstance/v3/attachments"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8108,6 +8204,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsAccountOptions model
 				listAttachmentsAccountOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsAccountOptions)
+				listAttachmentsAccountOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsAccountOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -8176,6 +8273,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsAccountOptions model
 				listAttachmentsAccountOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsAccountOptions)
+				listAttachmentsAccountOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsAccountOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -8187,7 +8285,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListAttachmentsAccount with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -8199,6 +8296,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsAccountOptions model
 				listAttachmentsAccountOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsAccountOptions)
+				listAttachmentsAccountOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsAccountOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -8236,6 +8334,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListAttachmentsAccountOptions model
 				listAttachmentsAccountOptionsModel := new(securityandcompliancecenterapiv3.ListAttachmentsAccountOptions)
+				listAttachmentsAccountOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listAttachmentsAccountOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.XRequestID = core.StringPtr("testString")
 				listAttachmentsAccountOptionsModel.Limit = core.Int64Ptr(int64(10))
@@ -8305,6 +8404,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsAccountOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsAccountOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -8332,6 +8432,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listAttachmentsAccountOptionsModel := &securityandcompliancecenterapiv3.ListAttachmentsAccountOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					Limit:          core.Int64Ptr(int64(10)),
@@ -8349,7 +8450,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetLatestReports(getLatestReportsOptions *GetLatestReportsOptions) - Operation response error`, func() {
-		getLatestReportsPath := "/reports/latest"
+		getLatestReportsPath := "/instances/testInstance/v3/reports/latest"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8378,6 +8479,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetLatestReportsOptions model
 				getLatestReportsOptionsModel := new(securityandcompliancecenterapiv3.GetLatestReportsOptions)
+				getLatestReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getLatestReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.Sort = core.StringPtr("profile_name")
@@ -8401,7 +8503,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetLatestReports(getLatestReportsOptions *GetLatestReportsOptions)`, func() {
-		getLatestReportsPath := "/reports/latest"
+		getLatestReportsPath := "/instances/testInstance/v3/reports/latest"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8436,6 +8538,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetLatestReportsOptions model
 				getLatestReportsOptionsModel := new(securityandcompliancecenterapiv3.GetLatestReportsOptions)
+				getLatestReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getLatestReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.Sort = core.StringPtr("profile_name")
@@ -8502,6 +8605,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetLatestReportsOptions model
 				getLatestReportsOptionsModel := new(securityandcompliancecenterapiv3.GetLatestReportsOptions)
+				getLatestReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getLatestReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.Sort = core.StringPtr("profile_name")
@@ -8512,7 +8616,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetLatestReports with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -8524,6 +8627,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetLatestReportsOptions model
 				getLatestReportsOptionsModel := new(securityandcompliancecenterapiv3.GetLatestReportsOptions)
+				getLatestReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getLatestReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.Sort = core.StringPtr("profile_name")
@@ -8560,6 +8664,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetLatestReportsOptions model
 				getLatestReportsOptionsModel := new(securityandcompliancecenterapiv3.GetLatestReportsOptions)
+				getLatestReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getLatestReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				getLatestReportsOptionsModel.Sort = core.StringPtr("profile_name")
@@ -8579,7 +8684,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReports(listReportsOptions *ListReportsOptions) - Operation response error`, func() {
-		listReportsPath := "/reports"
+		listReportsPath := "/instances/testInstance/v3/reports"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8614,6 +8719,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportsOptions model
 				listReportsOptionsModel := new(securityandcompliancecenterapiv3.ListReportsOptions)
+				listReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				listReportsOptionsModel.AttachmentID = core.StringPtr("testString")
@@ -8643,7 +8749,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReports(listReportsOptions *ListReportsOptions)`, func() {
-		listReportsPath := "/reports"
+		listReportsPath := "/instances/testInstance/v3/reports"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8684,6 +8790,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportsOptions model
 				listReportsOptionsModel := new(securityandcompliancecenterapiv3.ListReportsOptions)
+				listReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				listReportsOptionsModel.AttachmentID = core.StringPtr("testString")
@@ -8762,6 +8869,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportsOptions model
 				listReportsOptionsModel := new(securityandcompliancecenterapiv3.ListReportsOptions)
+				listReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				listReportsOptionsModel.AttachmentID = core.StringPtr("testString")
@@ -8778,7 +8886,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListReports with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -8790,6 +8897,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportsOptions model
 				listReportsOptionsModel := new(securityandcompliancecenterapiv3.ListReportsOptions)
+				listReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				listReportsOptionsModel.AttachmentID = core.StringPtr("testString")
@@ -8832,6 +8940,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportsOptions model
 				listReportsOptionsModel := new(securityandcompliancecenterapiv3.ListReportsOptions)
+				listReportsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportsOptionsModel.XRequestID = core.StringPtr("testString")
 				listReportsOptionsModel.AttachmentID = core.StringPtr("testString")
@@ -8916,6 +9025,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportsOptionsModel := &securityandcompliancecenterapiv3.ListReportsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					AttachmentID:   core.StringPtr("testString"),
@@ -8948,6 +9058,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportsOptionsModel := &securityandcompliancecenterapiv3.ListReportsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
 					AttachmentID:   core.StringPtr("testString"),
@@ -8970,7 +9081,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReport(getReportOptions *GetReportOptions) - Operation response error`, func() {
-		getReportPath := "/reports/testString"
+		getReportPath := "/instances/testInstance/v3/reports/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -8998,6 +9109,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportOptions model
 				getReportOptionsModel := new(securityandcompliancecenterapiv3.GetReportOptions)
+				getReportOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportOptionsModel.ReportID = core.StringPtr("testString")
 				getReportOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9021,7 +9133,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReport(getReportOptions *GetReportOptions)`, func() {
-		getReportPath := "/reports/testString"
+		getReportPath := "/instances/testInstance/v3/reports/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9055,6 +9167,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportOptions model
 				getReportOptionsModel := new(securityandcompliancecenterapiv3.GetReportOptions)
+				getReportOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportOptionsModel.ReportID = core.StringPtr("testString")
 				getReportOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9120,6 +9233,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportOptions model
 				getReportOptionsModel := new(securityandcompliancecenterapiv3.GetReportOptions)
+				getReportOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportOptionsModel.ReportID = core.StringPtr("testString")
 				getReportOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9130,7 +9244,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReport with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -9142,6 +9255,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportOptions model
 				getReportOptionsModel := new(securityandcompliancecenterapiv3.GetReportOptions)
+				getReportOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportOptionsModel.ReportID = core.StringPtr("testString")
 				getReportOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9185,6 +9299,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportOptions model
 				getReportOptionsModel := new(securityandcompliancecenterapiv3.GetReportOptions)
+				getReportOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportOptionsModel.ReportID = core.StringPtr("testString")
 				getReportOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9204,7 +9319,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportSummary(getReportSummaryOptions *GetReportSummaryOptions) - Operation response error`, func() {
-		getReportSummaryPath := "/reports/testString/summary"
+		getReportSummaryPath := "/instances/testInstance/v3/reports/testString/summary"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9232,6 +9347,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportSummaryOptions model
 				getReportSummaryOptionsModel := new(securityandcompliancecenterapiv3.GetReportSummaryOptions)
+				getReportSummaryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportSummaryOptionsModel.ReportID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9255,7 +9371,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportSummary(getReportSummaryOptions *GetReportSummaryOptions)`, func() {
-		getReportSummaryPath := "/reports/testString/summary"
+		getReportSummaryPath := "/instances/testInstance/v3/reports/testString/summary"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9289,6 +9405,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportSummaryOptions model
 				getReportSummaryOptionsModel := new(securityandcompliancecenterapiv3.GetReportSummaryOptions)
+				getReportSummaryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportSummaryOptionsModel.ReportID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9354,6 +9471,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportSummaryOptions model
 				getReportSummaryOptionsModel := new(securityandcompliancecenterapiv3.GetReportSummaryOptions)
+				getReportSummaryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportSummaryOptionsModel.ReportID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9364,7 +9482,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportSummary with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -9376,6 +9493,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportSummaryOptions model
 				getReportSummaryOptionsModel := new(securityandcompliancecenterapiv3.GetReportSummaryOptions)
+				getReportSummaryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportSummaryOptionsModel.ReportID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9419,6 +9537,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportSummaryOptions model
 				getReportSummaryOptionsModel := new(securityandcompliancecenterapiv3.GetReportSummaryOptions)
+				getReportSummaryOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportSummaryOptionsModel.ReportID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportSummaryOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9438,7 +9557,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportEvaluation(getReportEvaluationOptions *GetReportEvaluationOptions)`, func() {
-		getReportEvaluationPath := "/reports/testString/download"
+		getReportEvaluationPath := "/instances/testInstance/v3/reports/testString/download"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9473,6 +9592,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportEvaluationOptions model
 				getReportEvaluationOptionsModel := new(securityandcompliancecenterapiv3.GetReportEvaluationOptions)
+				getReportEvaluationOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportEvaluationOptionsModel.ReportID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9540,6 +9660,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportEvaluationOptions model
 				getReportEvaluationOptionsModel := new(securityandcompliancecenterapiv3.GetReportEvaluationOptions)
+				getReportEvaluationOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportEvaluationOptionsModel.ReportID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9551,7 +9672,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportEvaluation with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -9563,6 +9683,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportEvaluationOptions model
 				getReportEvaluationOptionsModel := new(securityandcompliancecenterapiv3.GetReportEvaluationOptions)
+				getReportEvaluationOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportEvaluationOptionsModel.ReportID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9607,6 +9728,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportEvaluationOptions model
 				getReportEvaluationOptionsModel := new(securityandcompliancecenterapiv3.GetReportEvaluationOptions)
+				getReportEvaluationOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportEvaluationOptionsModel.ReportID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportEvaluationOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9631,7 +9753,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportControls(getReportControlsOptions *GetReportControlsOptions) - Operation response error`, func() {
-		getReportControlsPath := "/reports/testString/controls"
+		getReportControlsPath := "/instances/testInstance/v3/reports/testString/controls"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9665,6 +9787,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportControlsOptions model
 				getReportControlsOptionsModel := new(securityandcompliancecenterapiv3.GetReportControlsOptions)
+				getReportControlsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportControlsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9694,7 +9817,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportControls(getReportControlsOptions *GetReportControlsOptions)`, func() {
-		getReportControlsPath := "/reports/testString/controls"
+		getReportControlsPath := "/instances/testInstance/v3/reports/testString/controls"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9734,6 +9857,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportControlsOptions model
 				getReportControlsOptionsModel := new(securityandcompliancecenterapiv3.GetReportControlsOptions)
+				getReportControlsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportControlsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9811,6 +9935,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportControlsOptions model
 				getReportControlsOptionsModel := new(securityandcompliancecenterapiv3.GetReportControlsOptions)
+				getReportControlsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportControlsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9827,7 +9952,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportControls with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -9839,6 +9963,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportControlsOptions model
 				getReportControlsOptionsModel := new(securityandcompliancecenterapiv3.GetReportControlsOptions)
+				getReportControlsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportControlsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9888,6 +10013,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportControlsOptions model
 				getReportControlsOptionsModel := new(securityandcompliancecenterapiv3.GetReportControlsOptions)
+				getReportControlsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportControlsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportControlsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -9913,7 +10039,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportRule(getReportRuleOptions *GetReportRuleOptions) - Operation response error`, func() {
-		getReportRulePath := "/reports/testString/rules/rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
+		getReportRulePath := "/instances/testInstance/v3/reports/testString/rules/rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9941,6 +10067,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportRuleOptions model
 				getReportRuleOptionsModel := new(securityandcompliancecenterapiv3.GetReportRuleOptions)
+				getReportRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportRuleOptionsModel.ReportID = core.StringPtr("testString")
 				getReportRuleOptionsModel.RuleID = core.StringPtr("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -9965,7 +10092,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportRule(getReportRuleOptions *GetReportRuleOptions)`, func() {
-		getReportRulePath := "/reports/testString/rules/rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
+		getReportRulePath := "/instances/testInstance/v3/reports/testString/rules/rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -9999,6 +10126,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportRuleOptions model
 				getReportRuleOptionsModel := new(securityandcompliancecenterapiv3.GetReportRuleOptions)
+				getReportRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportRuleOptionsModel.ReportID = core.StringPtr("testString")
 				getReportRuleOptionsModel.RuleID = core.StringPtr("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -10065,6 +10193,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportRuleOptions model
 				getReportRuleOptionsModel := new(securityandcompliancecenterapiv3.GetReportRuleOptions)
+				getReportRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportRuleOptionsModel.ReportID = core.StringPtr("testString")
 				getReportRuleOptionsModel.RuleID = core.StringPtr("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -10076,7 +10205,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportRule with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -10088,6 +10216,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportRuleOptions model
 				getReportRuleOptionsModel := new(securityandcompliancecenterapiv3.GetReportRuleOptions)
+				getReportRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportRuleOptionsModel.ReportID = core.StringPtr("testString")
 				getReportRuleOptionsModel.RuleID = core.StringPtr("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -10132,6 +10261,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportRuleOptions model
 				getReportRuleOptionsModel := new(securityandcompliancecenterapiv3.GetReportRuleOptions)
+				getReportRuleOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportRuleOptionsModel.ReportID = core.StringPtr("testString")
 				getReportRuleOptionsModel.RuleID = core.StringPtr("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -10152,7 +10282,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReportEvaluations(listReportEvaluationsOptions *ListReportEvaluationsOptions) - Operation response error`, func() {
-		listReportEvaluationsPath := "/reports/testString/evaluations"
+		listReportEvaluationsPath := "/instances/testInstance/v3/reports/testString/evaluations"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -10187,6 +10317,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportEvaluationsOptions model
 				listReportEvaluationsOptionsModel := new(securityandcompliancecenterapiv3.ListReportEvaluationsOptions)
+				listReportEvaluationsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportEvaluationsOptionsModel.ReportID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10217,7 +10348,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReportEvaluations(listReportEvaluationsOptions *ListReportEvaluationsOptions)`, func() {
-		listReportEvaluationsPath := "/reports/testString/evaluations"
+		listReportEvaluationsPath := "/instances/testInstance/v3/reports/testString/evaluations"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -10258,6 +10389,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportEvaluationsOptions model
 				listReportEvaluationsOptionsModel := new(securityandcompliancecenterapiv3.ListReportEvaluationsOptions)
+				listReportEvaluationsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportEvaluationsOptionsModel.ReportID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10337,6 +10469,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportEvaluationsOptions model
 				listReportEvaluationsOptionsModel := new(securityandcompliancecenterapiv3.ListReportEvaluationsOptions)
+				listReportEvaluationsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportEvaluationsOptionsModel.ReportID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10354,7 +10487,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListReportEvaluations with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -10366,6 +10498,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportEvaluationsOptions model
 				listReportEvaluationsOptionsModel := new(securityandcompliancecenterapiv3.ListReportEvaluationsOptions)
+				listReportEvaluationsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportEvaluationsOptionsModel.ReportID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10416,6 +10549,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportEvaluationsOptions model
 				listReportEvaluationsOptionsModel := new(securityandcompliancecenterapiv3.ListReportEvaluationsOptions)
+				listReportEvaluationsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportEvaluationsOptionsModel.ReportID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportEvaluationsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10501,6 +10635,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportEvaluationsOptionsModel := &securityandcompliancecenterapiv3.ListReportEvaluationsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ReportID:       core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -10534,6 +10669,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportEvaluationsOptionsModel := &securityandcompliancecenterapiv3.ListReportEvaluationsOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ReportID:       core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -10557,7 +10693,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReportResources(listReportResourcesOptions *ListReportResourcesOptions) - Operation response error`, func() {
-		listReportResourcesPath := "/reports/testString/resources"
+		listReportResourcesPath := "/instances/testInstance/v3/reports/testString/resources"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -10593,6 +10729,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportResourcesOptions model
 				listReportResourcesOptionsModel := new(securityandcompliancecenterapiv3.ListReportResourcesOptions)
+				listReportResourcesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportResourcesOptionsModel.ReportID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10624,7 +10761,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListReportResources(listReportResourcesOptions *ListReportResourcesOptions)`, func() {
-		listReportResourcesPath := "/reports/testString/resources"
+		listReportResourcesPath := "/instances/testInstance/v3/reports/testString/resources"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -10666,6 +10803,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportResourcesOptions model
 				listReportResourcesOptionsModel := new(securityandcompliancecenterapiv3.ListReportResourcesOptions)
+				listReportResourcesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportResourcesOptionsModel.ReportID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10747,6 +10885,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportResourcesOptions model
 				listReportResourcesOptionsModel := new(securityandcompliancecenterapiv3.ListReportResourcesOptions)
+				listReportResourcesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportResourcesOptionsModel.ReportID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10765,7 +10904,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListReportResources with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -10777,6 +10915,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportResourcesOptions model
 				listReportResourcesOptionsModel := new(securityandcompliancecenterapiv3.ListReportResourcesOptions)
+				listReportResourcesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportResourcesOptionsModel.ReportID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10828,6 +10967,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListReportResourcesOptions model
 				listReportResourcesOptionsModel := new(securityandcompliancecenterapiv3.ListReportResourcesOptions)
+				listReportResourcesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listReportResourcesOptionsModel.ReportID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listReportResourcesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -10914,6 +11054,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportResourcesOptionsModel := &securityandcompliancecenterapiv3.ListReportResourcesOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ReportID:       core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -10948,6 +11089,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(securityAndComplianceCenterApiService).ToNot(BeNil())
 
 				listReportResourcesOptionsModel := &securityandcompliancecenterapiv3.ListReportResourcesOptions{
+					InstanceID:     core.StringPtr("testInstance"),
 					ReportID:       core.StringPtr("testString"),
 					XCorrelationID: core.StringPtr("testString"),
 					XRequestID:     core.StringPtr("testString"),
@@ -10972,7 +11114,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportTags(getReportTagsOptions *GetReportTagsOptions) - Operation response error`, func() {
-		getReportTagsPath := "/reports/testString/tags"
+		getReportTagsPath := "/instances/testInstance/v3/reports/testString/tags"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11000,6 +11142,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportTagsOptions model
 				getReportTagsOptionsModel := new(securityandcompliancecenterapiv3.GetReportTagsOptions)
+				getReportTagsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportTagsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11023,7 +11166,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportTags(getReportTagsOptions *GetReportTagsOptions)`, func() {
-		getReportTagsPath := "/reports/testString/tags"
+		getReportTagsPath := "/instances/testInstance/v3/reports/testString/tags"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11057,6 +11200,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportTagsOptions model
 				getReportTagsOptionsModel := new(securityandcompliancecenterapiv3.GetReportTagsOptions)
+				getReportTagsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportTagsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11122,6 +11266,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportTagsOptions model
 				getReportTagsOptionsModel := new(securityandcompliancecenterapiv3.GetReportTagsOptions)
+				getReportTagsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportTagsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11132,7 +11277,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportTags with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -11144,6 +11288,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportTagsOptions model
 				getReportTagsOptionsModel := new(securityandcompliancecenterapiv3.GetReportTagsOptions)
+				getReportTagsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportTagsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11187,6 +11332,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportTagsOptions model
 				getReportTagsOptionsModel := new(securityandcompliancecenterapiv3.GetReportTagsOptions)
+				getReportTagsOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportTagsOptionsModel.ReportID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportTagsOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11206,7 +11352,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportViolationsDrift(getReportViolationsDriftOptions *GetReportViolationsDriftOptions) - Operation response error`, func() {
-		getReportViolationsDriftPath := "/reports/testString/violations_drift"
+		getReportViolationsDriftPath := "/instances/testInstance/v3/reports/testString/violations_drift"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11235,6 +11381,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportViolationsDriftOptions model
 				getReportViolationsDriftOptionsModel := new(securityandcompliancecenterapiv3.GetReportViolationsDriftOptions)
+				getReportViolationsDriftOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportViolationsDriftOptionsModel.ReportID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11259,7 +11406,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetReportViolationsDrift(getReportViolationsDriftOptions *GetReportViolationsDriftOptions)`, func() {
-		getReportViolationsDriftPath := "/reports/testString/violations_drift"
+		getReportViolationsDriftPath := "/instances/testInstance/v3/reports/testString/violations_drift"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11294,6 +11441,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportViolationsDriftOptions model
 				getReportViolationsDriftOptionsModel := new(securityandcompliancecenterapiv3.GetReportViolationsDriftOptions)
+				getReportViolationsDriftOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportViolationsDriftOptionsModel.ReportID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11361,6 +11509,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportViolationsDriftOptions model
 				getReportViolationsDriftOptionsModel := new(securityandcompliancecenterapiv3.GetReportViolationsDriftOptions)
+				getReportViolationsDriftOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportViolationsDriftOptionsModel.ReportID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11372,7 +11521,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetReportViolationsDrift with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -11384,6 +11532,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportViolationsDriftOptions model
 				getReportViolationsDriftOptionsModel := new(securityandcompliancecenterapiv3.GetReportViolationsDriftOptions)
+				getReportViolationsDriftOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportViolationsDriftOptionsModel.ReportID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11428,6 +11577,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetReportViolationsDriftOptions model
 				getReportViolationsDriftOptionsModel := new(securityandcompliancecenterapiv3.GetReportViolationsDriftOptions)
+				getReportViolationsDriftOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getReportViolationsDriftOptionsModel.ReportID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getReportViolationsDriftOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11448,7 +11598,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypes(listProviderTypesOptions *ListProviderTypesOptions) - Operation response error`, func() {
-		listProviderTypesPath := "/provider_types"
+		listProviderTypesPath := "/v3/provider_types"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11498,7 +11648,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypes(listProviderTypesOptions *ListProviderTypesOptions)`, func() {
-		listProviderTypesPath := "/provider_types"
+		listProviderTypesPath := "/v3/provider_types"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11605,7 +11755,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListProviderTypes with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -11670,7 +11819,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions) - Operation response error`, func() {
-		getProviderTypeByIDPath := "/provider_types/testString"
+		getProviderTypeByIDPath := "/v3/provider_types/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11721,7 +11870,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions)`, func() {
-		getProviderTypeByIDPath := "/provider_types/testString"
+		getProviderTypeByIDPath := "/v3/provider_types/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11830,7 +11979,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetProviderTypeByID with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -11904,7 +12052,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypeInstances(listProviderTypeInstancesOptions *ListProviderTypeInstancesOptions) - Operation response error`, func() {
-		listProviderTypeInstancesPath := "/provider_types/testString/provider_type_instances"
+		listProviderTypeInstancesPath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11932,6 +12080,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypeInstancesOptions model
 				listProviderTypeInstancesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypeInstancesOptions)
+				listProviderTypeInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypeInstancesOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11955,7 +12104,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypeInstances(listProviderTypeInstancesOptions *ListProviderTypeInstancesOptions)`, func() {
-		listProviderTypeInstancesPath := "/provider_types/testString/provider_type_instances"
+		listProviderTypeInstancesPath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11989,6 +12138,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypeInstancesOptions model
 				listProviderTypeInstancesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypeInstancesOptions)
+				listProviderTypeInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypeInstancesOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -12054,6 +12204,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypeInstancesOptions model
 				listProviderTypeInstancesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypeInstancesOptions)
+				listProviderTypeInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypeInstancesOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -12064,7 +12215,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke ListProviderTypeInstances with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -12076,6 +12226,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypeInstancesOptions model
 				listProviderTypeInstancesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypeInstancesOptions)
+				listProviderTypeInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypeInstancesOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -12119,6 +12270,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypeInstancesOptions model
 				listProviderTypeInstancesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypeInstancesOptions)
+				listProviderTypeInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypeInstancesOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypeInstancesOptionsModel.XRequestID = core.StringPtr("testString")
@@ -12138,7 +12290,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateProviderTypeInstance(createProviderTypeInstanceOptions *CreateProviderTypeInstanceOptions) - Operation response error`, func() {
-		createProviderTypeInstancePath := "/provider_types/testString/provider_type_instances"
+		createProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12166,6 +12318,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				createProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions)
+				createProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				createProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.Attributes = map[string]interface{}{"anyKey": "anyValue"}
@@ -12191,7 +12344,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`CreateProviderTypeInstance(createProviderTypeInstanceOptions *CreateProviderTypeInstanceOptions)`, func() {
-		createProviderTypeInstancePath := "/provider_types/testString/provider_type_instances"
+		createProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12241,6 +12394,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				createProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions)
+				createProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				createProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.Attributes = map[string]interface{}{"anyKey": "anyValue"}
@@ -12324,6 +12478,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				createProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions)
+				createProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				createProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.Attributes = map[string]interface{}{"anyKey": "anyValue"}
@@ -12336,7 +12491,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke CreateProviderTypeInstance with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -12348,6 +12502,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				createProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions)
+				createProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				createProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.Attributes = map[string]interface{}{"anyKey": "anyValue"}
@@ -12393,6 +12548,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				createProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions)
+				createProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				createProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				createProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.Attributes = map[string]interface{}{"anyKey": "anyValue"}
@@ -12414,7 +12570,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`DeleteProviderTypeInstance(deleteProviderTypeInstanceOptions *DeleteProviderTypeInstanceOptions)`, func() {
-		deleteProviderTypeInstancePath := "/provider_types/testString/provider_type_instances/testString"
+		deleteProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances/testString"
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12446,6 +12602,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProviderTypeInstanceOptions model
 				deleteProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.DeleteProviderTypeInstanceOptions)
+				deleteProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				deleteProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				deleteProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12467,6 +12624,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the DeleteProviderTypeInstanceOptions model
 				deleteProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.DeleteProviderTypeInstanceOptions)
+				deleteProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				deleteProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				deleteProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				deleteProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12492,7 +12650,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeInstance(getProviderTypeInstanceOptions *GetProviderTypeInstanceOptions) - Operation response error`, func() {
-		getProviderTypeInstancePath := "/provider_types/testString/provider_type_instances/testString"
+		getProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12520,6 +12678,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeInstanceOptions model
 				getProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeInstanceOptions)
+				getProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12544,7 +12703,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeInstance(getProviderTypeInstanceOptions *GetProviderTypeInstanceOptions)`, func() {
-		getProviderTypeInstancePath := "/provider_types/testString/provider_type_instances/testString"
+		getProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12578,6 +12737,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeInstanceOptions model
 				getProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeInstanceOptions)
+				getProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12644,6 +12804,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeInstanceOptions model
 				getProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeInstanceOptions)
+				getProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12655,7 +12816,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetProviderTypeInstance with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -12667,6 +12827,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeInstanceOptions model
 				getProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeInstanceOptions)
+				getProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12711,6 +12872,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeInstanceOptions model
 				getProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeInstanceOptions)
+				getProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				getProviderTypeInstanceOptionsModel.XCorrelationID = core.StringPtr("testString")
@@ -12731,7 +12893,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`UpdateProviderTypeInstance(updateProviderTypeInstanceOptions *UpdateProviderTypeInstanceOptions) - Operation response error`, func() {
-		updateProviderTypeInstancePath := "/provider_types/testString/provider_type_instances/testString"
+		updateProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12759,6 +12921,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
 				updateProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions)
+				updateProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
@@ -12785,7 +12948,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`UpdateProviderTypeInstance(updateProviderTypeInstanceOptions *UpdateProviderTypeInstanceOptions)`, func() {
-		updateProviderTypeInstancePath := "/provider_types/testString/provider_type_instances/testString"
+		updateProviderTypeInstancePath := "/instances/testInstance/v3/provider_types/testString/provider_type_instances/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -12835,6 +12998,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
 				updateProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions)
+				updateProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
@@ -12919,6 +13083,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
 				updateProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions)
+				updateProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
@@ -12932,7 +13097,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke UpdateProviderTypeInstance with error: Operation validation and request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -12944,6 +13108,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
 				updateProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions)
+				updateProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
@@ -12990,6 +13155,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
 				updateProviderTypeInstanceOptionsModel := new(securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions)
+				updateProviderTypeInstanceOptionsModel.InstanceID = core.StringPtr("testInstance")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.ProviderTypeInstanceID = core.StringPtr("testString")
 				updateProviderTypeInstanceOptionsModel.Name = core.StringPtr("workload-protection-instance-1")
@@ -13012,7 +13178,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypesInstances(getProviderTypesInstancesOptions *GetProviderTypesInstancesOptions) - Operation response error`, func() {
-		getProviderTypesInstancesPath := "/provider_types_instances"
+		getProviderTypesInstancesPath := "/v3/provider_types_instances"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -13062,7 +13228,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypesInstances(getProviderTypesInstancesOptions *GetProviderTypesInstancesOptions)`, func() {
-		getProviderTypesInstancesPath := "/provider_types_instances"
+		getProviderTypesInstancesPath := "/v3/provider_types_instances"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -13169,7 +13335,6 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
-
 			})
 			It(`Invoke GetProviderTypesInstances with error: Operation request error`, func() {
 				securityAndComplianceCenterApiService, serviceErr := securityandcompliancecenterapiv3.NewSecurityAndComplianceCenterApiV3(&securityandcompliancecenterapiv3.SecurityAndComplianceCenterApiV3Options{
@@ -13331,9 +13496,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(attachmentsPrototypeModel.AttachmentParameters).To(Equal([]securityandcompliancecenterapiv3.AttachmentParameterPrototype{*attachmentParameterPrototypeModel}))
 
 				// Construct an instance of the CreateAttachmentOptions model
+				instanceID := "testInstance"
 				profileID := "testString"
 				createAttachmentOptionsAttachments := []securityandcompliancecenterapiv3.AttachmentsPrototype{}
-				createAttachmentOptionsModel := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(profileID, createAttachmentOptionsAttachments)
+				createAttachmentOptionsModel := securityAndComplianceCenterApiService.NewCreateAttachmentOptions(instanceID, profileID, createAttachmentOptionsAttachments)
 				createAttachmentOptionsModel.SetProfileID("testString")
 				createAttachmentOptionsModel.SetAttachments([]securityandcompliancecenterapiv3.AttachmentsPrototype{*attachmentsPrototypeModel})
 				createAttachmentOptionsModel.SetProfileID("testString")
@@ -13430,11 +13596,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(controlsInControlLibModel.Status).To(Equal(core.StringPtr("enabled")))
 
 				// Construct an instance of the CreateCustomControlLibraryOptions model
+				instanceID := "testInstance"
 				createCustomControlLibraryOptionsControlLibraryName := "IBM Cloud for Financial Services"
 				createCustomControlLibraryOptionsControlLibraryDescription := "IBM Cloud for Financial Services"
 				createCustomControlLibraryOptionsControlLibraryType := "custom"
 				createCustomControlLibraryOptionsControls := []securityandcompliancecenterapiv3.ControlsInControlLib{}
-				createCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewCreateCustomControlLibraryOptions(createCustomControlLibraryOptionsControlLibraryName, createCustomControlLibraryOptionsControlLibraryDescription, createCustomControlLibraryOptionsControlLibraryType, createCustomControlLibraryOptionsControls)
+				createCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewCreateCustomControlLibraryOptions(instanceID, createCustomControlLibraryOptionsControlLibraryName, createCustomControlLibraryOptionsControlLibraryDescription, createCustomControlLibraryOptionsControlLibraryType, createCustomControlLibraryOptionsControls)
 				createCustomControlLibraryOptionsModel.SetControlLibraryName("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.SetControlLibraryDescription("IBM Cloud for Financial Services")
 				createCustomControlLibraryOptionsModel.SetControlLibraryType("custom")
@@ -13485,12 +13652,13 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(defaultParametersPrototypeModel.ParameterType).To(Equal(core.StringPtr("numeric")))
 
 				// Construct an instance of the CreateProfileOptions model
+				instanceID := "testInstance"
 				createProfileOptionsProfileName := "test_profile1"
 				createProfileOptionsProfileDescription := "test_description1"
 				createProfileOptionsProfileType := "custom"
 				createProfileOptionsControls := []securityandcompliancecenterapiv3.ProfileControlsPrototype{}
 				createProfileOptionsDefaultParameters := []securityandcompliancecenterapiv3.DefaultParametersPrototype{}
-				createProfileOptionsModel := securityAndComplianceCenterApiService.NewCreateProfileOptions(createProfileOptionsProfileName, createProfileOptionsProfileDescription, createProfileOptionsProfileType, createProfileOptionsControls, createProfileOptionsDefaultParameters)
+				createProfileOptionsModel := securityAndComplianceCenterApiService.NewCreateProfileOptions(instanceID, createProfileOptionsProfileName, createProfileOptionsProfileDescription, createProfileOptionsProfileType, createProfileOptionsControls, createProfileOptionsDefaultParameters)
 				createProfileOptionsModel.SetProfileName("test_profile1")
 				createProfileOptionsModel.SetProfileDescription("test_description1")
 				createProfileOptionsModel.SetProfileType("custom")
@@ -13512,7 +13680,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			It(`Invoke NewCreateProviderTypeInstanceOptions successfully`, func() {
 				// Construct an instance of the CreateProviderTypeInstanceOptions model
 				providerTypeID := "testString"
-				createProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewCreateProviderTypeInstanceOptions(providerTypeID)
+				instanceID := "testInstance"
+				createProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewCreateProviderTypeInstanceOptions(instanceID, providerTypeID)
 				createProviderTypeInstanceOptionsModel.SetProviderTypeID("testString")
 				createProviderTypeInstanceOptionsModel.SetName("workload-protection-instance-1")
 				createProviderTypeInstanceOptionsModel.SetAttributes(map[string]interface{}{"anyKey": "anyValue"})
@@ -13590,9 +13759,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the CreateRuleOptions model
 				createRuleOptionsDescription := "Example rule"
+				instanceID := "testInstance"
 				var createRuleOptionsTarget *securityandcompliancecenterapiv3.Target = nil
 				var createRuleOptionsRequiredConfig securityandcompliancecenterapiv3.RequiredConfigIntf = nil
-				createRuleOptionsModel := securityAndComplianceCenterApiService.NewCreateRuleOptions(createRuleOptionsDescription, createRuleOptionsTarget, createRuleOptionsRequiredConfig)
+				createRuleOptionsModel := securityAndComplianceCenterApiService.NewCreateRuleOptions(instanceID, createRuleOptionsDescription, createRuleOptionsTarget, createRuleOptionsRequiredConfig)
 				createRuleOptionsModel.SetDescription("Example rule")
 				createRuleOptionsModel.SetTarget(targetModel)
 				createRuleOptionsModel.SetRequiredConfig(requiredConfigModel)
@@ -13617,8 +13787,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewCreateScanOptions successfully`, func() {
 				// Construct an instance of the CreateScanOptions model
+				instanceID := "testInstance"
 				createScanOptionsAttachmentID := "testString"
-				createScanOptionsModel := securityAndComplianceCenterApiService.NewCreateScanOptions(createScanOptionsAttachmentID)
+				createScanOptionsModel := securityAndComplianceCenterApiService.NewCreateScanOptions(instanceID, createScanOptionsAttachmentID)
 				createScanOptionsModel.SetAttachmentID("testString")
 				createScanOptionsModel.SetXCorrelationID("testString")
 				createScanOptionsModel.SetXRequestID("testString")
@@ -13631,8 +13802,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteCustomControlLibraryOptions successfully`, func() {
 				// Construct an instance of the DeleteCustomControlLibraryOptions model
+				instanceID := "testInstance"
 				controlLibrariesID := "testString"
-				deleteCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomControlLibraryOptions(controlLibrariesID)
+				deleteCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomControlLibraryOptions(instanceID, controlLibrariesID)
 				deleteCustomControlLibraryOptionsModel.SetControlLibrariesID("testString")
 				deleteCustomControlLibraryOptionsModel.SetXCorrelationID("testString")
 				deleteCustomControlLibraryOptionsModel.SetXRequestID("testString")
@@ -13645,8 +13817,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteCustomProfileOptions successfully`, func() {
 				// Construct an instance of the DeleteCustomProfileOptions model
+				instanceID := "testInstance"
 				profileID := "testString"
-				deleteCustomProfileOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(profileID)
+				deleteCustomProfileOptionsModel := securityAndComplianceCenterApiService.NewDeleteCustomProfileOptions(instanceID, profileID)
 				deleteCustomProfileOptionsModel.SetProfileID("testString")
 				deleteCustomProfileOptionsModel.SetXCorrelationID("testString")
 				deleteCustomProfileOptionsModel.SetXRequestID("testString")
@@ -13659,9 +13832,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteProfileAttachmentOptions successfully`, func() {
 				// Construct an instance of the DeleteProfileAttachmentOptions model
+				instanceID := "testInstance"
 				attachmentID := "testString"
 				profileID := "testString"
-				deleteProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(attachmentID, profileID)
+				deleteProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewDeleteProfileAttachmentOptions(instanceID, attachmentID, profileID)
 				deleteProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				deleteProfileAttachmentOptionsModel.SetProfileID("testString")
 				deleteProfileAttachmentOptionsModel.SetXCorrelationID("testString")
@@ -13676,9 +13850,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteProviderTypeInstanceOptions successfully`, func() {
 				// Construct an instance of the DeleteProviderTypeInstanceOptions model
+				instanceID := "testInstance"
 				providerTypeID := "testString"
 				providerTypeInstanceID := "testString"
-				deleteProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewDeleteProviderTypeInstanceOptions(providerTypeID, providerTypeInstanceID)
+				deleteProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewDeleteProviderTypeInstanceOptions(instanceID, providerTypeID, providerTypeInstanceID)
 				deleteProviderTypeInstanceOptionsModel.SetProviderTypeID("testString")
 				deleteProviderTypeInstanceOptionsModel.SetProviderTypeInstanceID("testString")
 				deleteProviderTypeInstanceOptionsModel.SetXCorrelationID("testString")
@@ -13693,8 +13868,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewDeleteRuleOptions successfully`, func() {
 				// Construct an instance of the DeleteRuleOptions model
+				instanceID := "testInstance"
 				ruleID := "testString"
-				deleteRuleOptionsModel := securityAndComplianceCenterApiService.NewDeleteRuleOptions(ruleID)
+				deleteRuleOptionsModel := securityAndComplianceCenterApiService.NewDeleteRuleOptions(instanceID, ruleID)
 				deleteRuleOptionsModel.SetRuleID("testString")
 				deleteRuleOptionsModel.SetXCorrelationID("testString")
 				deleteRuleOptionsModel.SetXRequestID("testString")
@@ -13707,8 +13883,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetControlLibraryOptions successfully`, func() {
 				// Construct an instance of the GetControlLibraryOptions model
+				instanceID := "testInstance"
 				controlLibrariesID := "testString"
-				getControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewGetControlLibraryOptions(controlLibrariesID)
+				getControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewGetControlLibraryOptions(instanceID, controlLibrariesID)
 				getControlLibraryOptionsModel.SetControlLibrariesID("testString")
 				getControlLibraryOptionsModel.SetXCorrelationID("testString")
 				getControlLibraryOptionsModel.SetXRequestID("testString")
@@ -13721,7 +13898,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetLatestReportsOptions successfully`, func() {
 				// Construct an instance of the GetLatestReportsOptions model
-				getLatestReportsOptionsModel := securityAndComplianceCenterApiService.NewGetLatestReportsOptions()
+				instanceID := "testInstance"
+				getLatestReportsOptionsModel := securityAndComplianceCenterApiService.NewGetLatestReportsOptions(instanceID)
 				getLatestReportsOptionsModel.SetXCorrelationID("testString")
 				getLatestReportsOptionsModel.SetXRequestID("testString")
 				getLatestReportsOptionsModel.SetSort("profile_name")
@@ -13734,9 +13912,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetProfileAttachmentOptions successfully`, func() {
 				// Construct an instance of the GetProfileAttachmentOptions model
+				instanceID := "testInstance"
 				attachmentID := "testString"
 				profileID := "testString"
-				getProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(attachmentID, profileID)
+				getProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewGetProfileAttachmentOptions(instanceID, attachmentID, profileID)
 				getProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				getProfileAttachmentOptionsModel.SetProfileID("testString")
 				getProfileAttachmentOptionsModel.SetXCorrelationID("testString")
@@ -13751,8 +13930,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetProfileOptions successfully`, func() {
 				// Construct an instance of the GetProfileOptions model
+				instanceID := "testInstance"
 				profileID := "testString"
-				getProfileOptionsModel := securityAndComplianceCenterApiService.NewGetProfileOptions(profileID)
+				getProfileOptionsModel := securityAndComplianceCenterApiService.NewGetProfileOptions(instanceID, profileID)
 				getProfileOptionsModel.SetProfileID("testString")
 				getProfileOptionsModel.SetXCorrelationID("testString")
 				getProfileOptionsModel.SetXRequestID("testString")
@@ -13779,9 +13959,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetProviderTypeInstanceOptions successfully`, func() {
 				// Construct an instance of the GetProviderTypeInstanceOptions model
+				instanceID := "testInstance"
 				providerTypeID := "testString"
 				providerTypeInstanceID := "testString"
-				getProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypeInstanceOptions(providerTypeID, providerTypeInstanceID)
+				getProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypeInstanceOptions(instanceID, providerTypeID, providerTypeInstanceID)
 				getProviderTypeInstanceOptionsModel.SetProviderTypeID("testString")
 				getProviderTypeInstanceOptionsModel.SetProviderTypeInstanceID("testString")
 				getProviderTypeInstanceOptionsModel.SetXCorrelationID("testString")
@@ -13807,8 +13988,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportControlsOptions successfully`, func() {
 				// Construct an instance of the GetReportControlsOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportControlsOptionsModel := securityAndComplianceCenterApiService.NewGetReportControlsOptions(reportID)
+				getReportControlsOptionsModel := securityAndComplianceCenterApiService.NewGetReportControlsOptions(instanceID, reportID)
 				getReportControlsOptionsModel.SetReportID("testString")
 				getReportControlsOptionsModel.SetXCorrelationID("testString")
 				getReportControlsOptionsModel.SetXRequestID("testString")
@@ -13833,8 +14015,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportEvaluationOptions successfully`, func() {
 				// Construct an instance of the GetReportEvaluationOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportEvaluationOptionsModel := securityAndComplianceCenterApiService.NewGetReportEvaluationOptions(reportID)
+				getReportEvaluationOptionsModel := securityAndComplianceCenterApiService.NewGetReportEvaluationOptions(instanceID, reportID)
 				getReportEvaluationOptionsModel.SetReportID("testString")
 				getReportEvaluationOptionsModel.SetXCorrelationID("testString")
 				getReportEvaluationOptionsModel.SetXRequestID("testString")
@@ -13849,8 +14032,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportOptions successfully`, func() {
 				// Construct an instance of the GetReportOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportOptionsModel := securityAndComplianceCenterApiService.NewGetReportOptions(reportID)
+				getReportOptionsModel := securityAndComplianceCenterApiService.NewGetReportOptions(instanceID, reportID)
 				getReportOptionsModel.SetReportID("testString")
 				getReportOptionsModel.SetXCorrelationID("testString")
 				getReportOptionsModel.SetXRequestID("testString")
@@ -13863,9 +14047,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportRuleOptions successfully`, func() {
 				// Construct an instance of the GetReportRuleOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
 				ruleID := "rule-8d444f8c-fd1d-48de-bcaa-f43732568761"
-				getReportRuleOptionsModel := securityAndComplianceCenterApiService.NewGetReportRuleOptions(reportID, ruleID)
+				getReportRuleOptionsModel := securityAndComplianceCenterApiService.NewGetReportRuleOptions(instanceID, reportID, ruleID)
 				getReportRuleOptionsModel.SetReportID("testString")
 				getReportRuleOptionsModel.SetRuleID("rule-8d444f8c-fd1d-48de-bcaa-f43732568761")
 				getReportRuleOptionsModel.SetXCorrelationID("testString")
@@ -13880,8 +14065,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportSummaryOptions successfully`, func() {
 				// Construct an instance of the GetReportSummaryOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportSummaryOptionsModel := securityAndComplianceCenterApiService.NewGetReportSummaryOptions(reportID)
+				getReportSummaryOptionsModel := securityAndComplianceCenterApiService.NewGetReportSummaryOptions(instanceID, reportID)
 				getReportSummaryOptionsModel.SetReportID("testString")
 				getReportSummaryOptionsModel.SetXCorrelationID("testString")
 				getReportSummaryOptionsModel.SetXRequestID("testString")
@@ -13894,8 +14080,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportTagsOptions successfully`, func() {
 				// Construct an instance of the GetReportTagsOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportTagsOptionsModel := securityAndComplianceCenterApiService.NewGetReportTagsOptions(reportID)
+				getReportTagsOptionsModel := securityAndComplianceCenterApiService.NewGetReportTagsOptions(instanceID, reportID)
 				getReportTagsOptionsModel.SetReportID("testString")
 				getReportTagsOptionsModel.SetXCorrelationID("testString")
 				getReportTagsOptionsModel.SetXRequestID("testString")
@@ -13908,8 +14095,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetReportViolationsDriftOptions successfully`, func() {
 				// Construct an instance of the GetReportViolationsDriftOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				getReportViolationsDriftOptionsModel := securityAndComplianceCenterApiService.NewGetReportViolationsDriftOptions(reportID)
+				getReportViolationsDriftOptionsModel := securityAndComplianceCenterApiService.NewGetReportViolationsDriftOptions(instanceID, reportID)
 				getReportViolationsDriftOptionsModel.SetReportID("testString")
 				getReportViolationsDriftOptionsModel.SetXCorrelationID("testString")
 				getReportViolationsDriftOptionsModel.SetXRequestID("testString")
@@ -13924,8 +14112,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetRuleOptions successfully`, func() {
 				// Construct an instance of the GetRuleOptions model
+				instanceID := "testInstance"
 				ruleID := "testString"
-				getRuleOptionsModel := securityAndComplianceCenterApiService.NewGetRuleOptions(ruleID)
+				getRuleOptionsModel := securityAndComplianceCenterApiService.NewGetRuleOptions(instanceID, ruleID)
 				getRuleOptionsModel.SetRuleID("testString")
 				getRuleOptionsModel.SetXCorrelationID("testString")
 				getRuleOptionsModel.SetXRequestID("testString")
@@ -13938,7 +14127,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetSettingsOptions successfully`, func() {
 				// Construct an instance of the GetSettingsOptions model
-				getSettingsOptionsModel := securityAndComplianceCenterApiService.NewGetSettingsOptions()
+				instanceID := "testInstance"
+				getSettingsOptionsModel := securityAndComplianceCenterApiService.NewGetSettingsOptions(instanceID)
 				getSettingsOptionsModel.SetXCorrelationID("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				getSettingsOptionsModel.SetXRequestID("testString")
 				getSettingsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -13949,7 +14139,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListAttachmentsAccountOptions successfully`, func() {
 				// Construct an instance of the ListAttachmentsAccountOptions model
-				listAttachmentsAccountOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsAccountOptions()
+				instanceID := "testInstance"
+				listAttachmentsAccountOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsAccountOptions(instanceID)
 				listAttachmentsAccountOptionsModel.SetXCorrelationID("testString")
 				listAttachmentsAccountOptionsModel.SetXRequestID("testString")
 				listAttachmentsAccountOptionsModel.SetLimit(int64(10))
@@ -13982,7 +14173,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListControlLibrariesOptions successfully`, func() {
 				// Construct an instance of the ListControlLibrariesOptions model
-				listControlLibrariesOptionsModel := securityAndComplianceCenterApiService.NewListControlLibrariesOptions()
+				instanceID := "testInstance"
+				listControlLibrariesOptionsModel := securityAndComplianceCenterApiService.NewListControlLibrariesOptions(instanceID)
 				listControlLibrariesOptionsModel.SetXCorrelationID("testString")
 				listControlLibrariesOptionsModel.SetXRequestID("testString")
 				listControlLibrariesOptionsModel.SetLimit(int64(50))
@@ -13999,7 +14191,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListProfilesOptions successfully`, func() {
 				// Construct an instance of the ListProfilesOptions model
-				listProfilesOptionsModel := securityAndComplianceCenterApiService.NewListProfilesOptions()
+				instanceID := "testInstance"
+				listProfilesOptionsModel := securityAndComplianceCenterApiService.NewListProfilesOptions(instanceID)
 				listProfilesOptionsModel.SetXCorrelationID("testString")
 				listProfilesOptionsModel.SetXRequestID("testString")
 				listProfilesOptionsModel.SetLimit(int64(10))
@@ -14016,8 +14209,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListProviderTypeInstancesOptions successfully`, func() {
 				// Construct an instance of the ListProviderTypeInstancesOptions model
+				instanceID := "testInstance"
 				providerTypeID := "testString"
-				listProviderTypeInstancesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypeInstancesOptions(providerTypeID)
+				listProviderTypeInstancesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypeInstancesOptions(instanceID, providerTypeID)
 				listProviderTypeInstancesOptionsModel.SetProviderTypeID("testString")
 				listProviderTypeInstancesOptionsModel.SetXCorrelationID("testString")
 				listProviderTypeInstancesOptionsModel.SetXRequestID("testString")
@@ -14030,7 +14224,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListProviderTypesOptions successfully`, func() {
 				// Construct an instance of the ListProviderTypesOptions model
-				listProviderTypesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypesOptions()
+				instanceID := "testInstance"
+				listProviderTypesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypesOptions(instanceID)
 				listProviderTypesOptionsModel.SetXCorrelationID("testString")
 				listProviderTypesOptionsModel.SetXRequestID("testString")
 				listProviderTypesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -14041,8 +14236,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListReportEvaluationsOptions successfully`, func() {
 				// Construct an instance of the ListReportEvaluationsOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				listReportEvaluationsOptionsModel := securityAndComplianceCenterApiService.NewListReportEvaluationsOptions(reportID)
+				listReportEvaluationsOptionsModel := securityAndComplianceCenterApiService.NewListReportEvaluationsOptions(instanceID, reportID)
 				listReportEvaluationsOptionsModel.SetReportID("testString")
 				listReportEvaluationsOptionsModel.SetXCorrelationID("testString")
 				listReportEvaluationsOptionsModel.SetXRequestID("testString")
@@ -14069,8 +14265,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListReportResourcesOptions successfully`, func() {
 				// Construct an instance of the ListReportResourcesOptions model
+				instanceID := "testInstance"
 				reportID := "testString"
-				listReportResourcesOptionsModel := securityAndComplianceCenterApiService.NewListReportResourcesOptions(reportID)
+				listReportResourcesOptionsModel := securityAndComplianceCenterApiService.NewListReportResourcesOptions(instanceID, reportID)
 				listReportResourcesOptionsModel.SetReportID("testString")
 				listReportResourcesOptionsModel.SetXCorrelationID("testString")
 				listReportResourcesOptionsModel.SetXRequestID("testString")
@@ -14099,7 +14296,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListReportsOptions successfully`, func() {
 				// Construct an instance of the ListReportsOptions model
-				listReportsOptionsModel := securityAndComplianceCenterApiService.NewListReportsOptions()
+				instanceID := "testInstance"
+				listReportsOptionsModel := securityAndComplianceCenterApiService.NewListReportsOptions(instanceID)
 				listReportsOptionsModel.SetXCorrelationID("testString")
 				listReportsOptionsModel.SetXRequestID("testString")
 				listReportsOptionsModel.SetAttachmentID("testString")
@@ -14148,7 +14346,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewPostTestEventOptions successfully`, func() {
 				// Construct an instance of the PostTestEventOptions model
-				postTestEventOptionsModel := securityAndComplianceCenterApiService.NewPostTestEventOptions()
+				instanceID := "testInstance"
+				postTestEventOptionsModel := securityAndComplianceCenterApiService.NewPostTestEventOptions(instanceID)
 				postTestEventOptionsModel.SetXCorrelationID("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")
 				postTestEventOptionsModel.SetXRequestID("testString")
 				postTestEventOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -14239,8 +14438,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(controlsInControlLibModel.Status).To(Equal(core.StringPtr("enabled")))
 
 				// Construct an instance of the ReplaceCustomControlLibraryOptions model
+				instanceID := "testInstance"
 				controlLibrariesID := "testString"
-				replaceCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewReplaceCustomControlLibraryOptions(controlLibrariesID)
+				replaceCustomControlLibraryOptionsModel := securityAndComplianceCenterApiService.NewReplaceCustomControlLibraryOptions(instanceID, controlLibrariesID)
 				replaceCustomControlLibraryOptionsModel.SetControlLibrariesID("testString")
 				replaceCustomControlLibraryOptionsModel.SetID("testString")
 				replaceCustomControlLibraryOptionsModel.SetAccountID("testString")
@@ -14343,9 +14543,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(lastScanModel.Time).To(Equal(CreateMockDateTime("2019-01-01T12:00:00.000Z")))
 
 				// Construct an instance of the ReplaceProfileAttachmentOptions model
+				instanceID := "testInstance"
 				attachmentID := "testString"
 				profileID := "testString"
-				replaceProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(attachmentID, profileID)
+				replaceProfileAttachmentOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileAttachmentOptions(instanceID, attachmentID, profileID)
 				replaceProfileAttachmentOptionsModel.SetAttachmentID("testString")
 				replaceProfileAttachmentOptionsModel.SetProfileID("testString")
 				replaceProfileAttachmentOptionsModel.SetID("testString")
@@ -14418,13 +14619,14 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(defaultParametersPrototypeModel.ParameterType).To(Equal(core.StringPtr("numeric")))
 
 				// Construct an instance of the ReplaceProfileOptions model
+				instanceID := "testInstance"
 				profileID := "testString"
 				replaceProfileOptionsProfileName := "test_profile1"
 				replaceProfileOptionsProfileDescription := "test_description1"
 				replaceProfileOptionsProfileType := "custom"
 				replaceProfileOptionsControls := []securityandcompliancecenterapiv3.ProfileControlsPrototype{}
 				replaceProfileOptionsDefaultParameters := []securityandcompliancecenterapiv3.DefaultParametersPrototype{}
-				replaceProfileOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileOptions(profileID, replaceProfileOptionsProfileName, replaceProfileOptionsProfileDescription, replaceProfileOptionsProfileType, replaceProfileOptionsControls, replaceProfileOptionsDefaultParameters)
+				replaceProfileOptionsModel := securityAndComplianceCenterApiService.NewReplaceProfileOptions(instanceID, profileID, replaceProfileOptionsProfileName, replaceProfileOptionsProfileDescription, replaceProfileOptionsProfileType, replaceProfileOptionsControls, replaceProfileOptionsDefaultParameters)
 				replaceProfileOptionsModel.SetProfileID("testString")
 				replaceProfileOptionsModel.SetProfileName("test_profile1")
 				replaceProfileOptionsModel.SetProfileDescription("test_description1")
@@ -14507,12 +14709,13 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(importModel.Parameters).To(Equal([]securityandcompliancecenterapiv3.Parameter{*parameterModel}))
 
 				// Construct an instance of the ReplaceRuleOptions model
+				instanceID := "testInstance"
 				ruleID := "testString"
 				ifMatch := "testString"
 				replaceRuleOptionsDescription := "Example rule"
 				var replaceRuleOptionsTarget *securityandcompliancecenterapiv3.Target = nil
 				var replaceRuleOptionsRequiredConfig securityandcompliancecenterapiv3.RequiredConfigIntf = nil
-				replaceRuleOptionsModel := securityAndComplianceCenterApiService.NewReplaceRuleOptions(ruleID, ifMatch, replaceRuleOptionsDescription, replaceRuleOptionsTarget, replaceRuleOptionsRequiredConfig)
+				replaceRuleOptionsModel := securityAndComplianceCenterApiService.NewReplaceRuleOptions(instanceID, ruleID, ifMatch, replaceRuleOptionsDescription, replaceRuleOptionsTarget, replaceRuleOptionsRequiredConfig)
 				replaceRuleOptionsModel.SetRuleID("testString")
 				replaceRuleOptionsModel.SetIfMatch("testString")
 				replaceRuleOptionsModel.SetDescription("Example rule")
@@ -14548,9 +14751,10 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewUpdateProviderTypeInstanceOptions successfully`, func() {
 				// Construct an instance of the UpdateProviderTypeInstanceOptions model
+				instanceID := "testInstance"
 				providerTypeID := "testString"
 				providerTypeInstanceID := "testString"
-				updateProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewUpdateProviderTypeInstanceOptions(providerTypeID, providerTypeInstanceID)
+				updateProviderTypeInstanceOptionsModel := securityAndComplianceCenterApiService.NewUpdateProviderTypeInstanceOptions(instanceID, providerTypeID, providerTypeInstanceID)
 				updateProviderTypeInstanceOptionsModel.SetProviderTypeID("testString")
 				updateProviderTypeInstanceOptionsModel.SetProviderTypeInstanceID("testString")
 				updateProviderTypeInstanceOptionsModel.SetName("workload-protection-instance-1")
@@ -14597,7 +14801,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 				Expect(objectStorageModel.UpdatedOn).To(Equal(CreateMockDateTime("2019-01-01T12:00:00.000Z")))
 
 				// Construct an instance of the UpdateSettingsOptions model
-				updateSettingsOptionsModel := securityAndComplianceCenterApiService.NewUpdateSettingsOptions()
+				instanceID := "testInstance"
+				updateSettingsOptionsModel := securityAndComplianceCenterApiService.NewUpdateSettingsOptions(instanceID)
 				updateSettingsOptionsModel.SetEventNotifications(eventNotificationsModel)
 				updateSettingsOptionsModel.SetObjectStorage(objectStorageModel)
 				updateSettingsOptionsModel.SetXCorrelationID("1a2b3c4d-5e6f-4a7b-8c9d-e0f1a2b3c4d5")

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -13178,7 +13178,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypesInstances(getProviderTypesInstancesOptions *GetProviderTypesInstancesOptions) - Operation response error`, func() {
-		getProviderTypesInstancesPath := "/v3/provider_types_instances"
+		getProviderTypesInstancesPath := "/instances/testInstance/v3/provider_types_instances"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -13206,6 +13206,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypesInstancesOptions model
 				getProviderTypesInstancesOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions)
+				getProviderTypesInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypesInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.XRequestID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -13228,7 +13229,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypesInstances(getProviderTypesInstancesOptions *GetProviderTypesInstancesOptions)`, func() {
-		getProviderTypesInstancesPath := "/v3/provider_types_instances"
+		getProviderTypesInstancesPath := "/instances/testInstance/v3/provider_types_instances"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -13262,6 +13263,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypesInstancesOptions model
 				getProviderTypesInstancesOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions)
+				getProviderTypesInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypesInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.XRequestID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -13326,6 +13328,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypesInstancesOptions model
 				getProviderTypesInstancesOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions)
+				getProviderTypesInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypesInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.XRequestID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -13346,6 +13349,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypesInstancesOptions model
 				getProviderTypesInstancesOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions)
+				getProviderTypesInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypesInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.XRequestID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -13381,6 +13385,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypesInstancesOptions model
 				getProviderTypesInstancesOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypesInstancesOptions)
+				getProviderTypesInstancesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypesInstancesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.XRequestID = core.StringPtr("testString")
 				getProviderTypesInstancesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -13982,7 +13982,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewGetProviderTypesInstancesOptions successfully`, func() {
 				// Construct an instance of the GetProviderTypesInstancesOptions model
-				getProviderTypesInstancesOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypesInstancesOptions()
+				instanceID := "testInstance"
+				getProviderTypesInstancesOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypesInstancesOptions(instanceID)
 				getProviderTypesInstancesOptionsModel.SetXCorrelationID("testString")
 				getProviderTypesInstancesOptionsModel.SetXRequestID("testString")
 				getProviderTypesInstancesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -14160,8 +14161,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListAttachmentsOptions successfully`, func() {
 				// Construct an instance of the ListAttachmentsOptions model
+				instanceID := "testInstance"
 				profileID := "testString"
-				listAttachmentsOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsOptions(profileID)
+				listAttachmentsOptionsModel := securityAndComplianceCenterApiService.NewListAttachmentsOptions(instanceID, profileID)
 				listAttachmentsOptionsModel.SetProfileID("testString")
 				listAttachmentsOptionsModel.SetXCorrelationID("testString")
 				listAttachmentsOptionsModel.SetXRequestID("testString")
@@ -14229,8 +14231,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListProviderTypesOptions successfully`, func() {
 				// Construct an instance of the ListProviderTypesOptions model
-				instanceID := "testInstance"
-				listProviderTypesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypesOptions(instanceID)
+				listProviderTypesOptionsModel := securityAndComplianceCenterApiService.NewListProviderTypesOptions()
 				listProviderTypesOptionsModel.SetXCorrelationID("testString")
 				listProviderTypesOptionsModel.SetXRequestID("testString")
 				listProviderTypesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -14327,7 +14328,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			})
 			It(`Invoke NewListRulesOptions successfully`, func() {
 				// Construct an instance of the ListRulesOptions model
-				listRulesOptionsModel := securityAndComplianceCenterApiService.NewListRulesOptions()
+				instanceID := "testInstance"
+				listRulesOptionsModel := securityAndComplianceCenterApiService.NewListRulesOptions(instanceID)
 				listRulesOptionsModel.SetXCorrelationID("testString")
 				listRulesOptionsModel.SetXRequestID("testString")
 				listRulesOptionsModel.SetType("system_defined")


### PR DESCRIPTION
## PR summary
Adding the field `instance_id` to various API calls, allowing the SDK to target multiple instances at once. 

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Test Evidence:
```shell
$ make test
cd v5 && go test `go list ./...`
ok      github.com/IBM/scc-go-sdk/v5/common     (cached)
ok      github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3   14.981s

```

Integration Test Evidence:
```shell
$ make test-int                                             
cd v5 && go test `go list ./...` -tags=integration
ok      github.com/IBM/scc-go-sdk/v5/common     (cached)
ok      github.com/IBM/scc-go-sdk/v5/securityandcompliancecenterapiv3   248.107s
```
