### PR TITLE
Fix: Add profile_version in the ReplaceProfileOptions

### DIFF
--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -3121,7 +3121,7 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProv
 	if err != nil {
 		return
 	}
-	_, err = builder.ResolveRequestURL(instanceURL, `/v3/provider_types`, nil)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types`, nil)
 	if err != nil {
 		return
 	}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -3117,7 +3117,11 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) ListProv
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types`, nil)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *listProviderTypesOptions.InstanceID)
+	if err != nil {
+		return
+	}
+	_, err = builder.ResolveRequestURL(instanceURL, `/v3/provider_types`, nil)
 	if err != nil {
 		return
 	}
@@ -7929,6 +7933,9 @@ func (options *ListProviderTypeInstancesOptions) SetHeaders(param map[string]str
 
 // ListProviderTypesOptions : The ListProviderTypes options.
 type ListProviderTypesOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
 	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
 	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
@@ -7946,6 +7953,12 @@ type ListProviderTypesOptions struct {
 // NewListProviderTypesOptions : Instantiate ListProviderTypesOptions
 func (*SecurityAndComplianceCenterApiV3) NewListProviderTypesOptions() *ListProviderTypesOptions {
 	return &ListProviderTypesOptions{}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *ListProviderTypesOptions) SetInstanceID(instanceID string) *ListProviderTypesOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetXCorrelationID : Allow user to set XCorrelationID

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -9940,6 +9940,9 @@ type ReplaceProfileOptions struct {
 	// The profile type.
 	ProfileType *string `json:"profile_type" validate:"required"`
 
+	// The version status of the profile.
+	ProfileVersion *string `json:"profile_version,omitempty"`
+
 	// The controls that are in the profile.
 	Controls []ProfileControlsPrototype `json:"controls" validate:"required"`
 
@@ -10007,6 +10010,12 @@ func (_options *ReplaceProfileOptions) SetProfileDescription(profileDescription 
 // SetProfileType : Allow user to set ProfileType
 func (_options *ReplaceProfileOptions) SetProfileType(profileType string) *ReplaceProfileOptions {
 	_options.ProfileType = core.StringPtr(profileType)
+	return _options
+}
+
+// SetProfileVersion : Allow user to set ProfileType
+func (_options *ReplaceProfileOptions) SetProfileVersion(profileVersion string) *ReplaceProfileOptions {
+	_options.ProfileVersion = core.StringPtr(profileVersion)
 	return _options
 }
 

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -741,6 +741,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 				ProfileName:        core.StringPtr("scc-go-sdk test_profile"),
 				ProfileDescription: core.StringPtr("test_description1"),
 				ProfileType:        core.StringPtr("custom"),
+				ProfileVersion:     core.StringPtr("0.0.1"),
 				Controls:           []securityandcompliancecenterapiv3.ProfileControlsPrototype{*profileControlsPrototypeModel},
 				DefaultParameters:  []securityandcompliancecenterapiv3.DefaultParametersPrototype{*defaultParametersPrototypeModel},
 				XCorrelationID:     core.StringPtr("testString"),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -1519,6 +1519,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`ListProviderTypes(listProviderTypesOptions *ListProviderTypesOptions)`, func() {
 			listProviderTypesOptions := &securityandcompliancecenterapiv3.ListProviderTypesOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 			}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -11598,7 +11598,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypes(listProviderTypesOptions *ListProviderTypesOptions) - Operation response error`, func() {
-		listProviderTypesPath := "/v3/provider_types"
+		listProviderTypesPath := "/instances/testInstance/v3/provider_types"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11626,6 +11626,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypesOptions model
 				listProviderTypesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypesOptions)
+				listProviderTypesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -11648,7 +11649,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`ListProviderTypes(listProviderTypesOptions *ListProviderTypesOptions)`, func() {
-		listProviderTypesPath := "/v3/provider_types"
+		listProviderTypesPath := "/instances/testInstance/v3/provider_types"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11682,6 +11683,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypesOptions model
 				listProviderTypesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypesOptions)
+				listProviderTypesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -11746,6 +11748,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypesOptions model
 				listProviderTypesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypesOptions)
+				listProviderTypesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -11766,6 +11769,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypesOptions model
 				listProviderTypesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypesOptions)
+				listProviderTypesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -11801,6 +11805,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the ListProviderTypesOptions model
 				listProviderTypesOptionsModel := new(securityandcompliancecenterapiv3.ListProviderTypesOptions)
+				listProviderTypesOptionsModel.InstanceID = core.StringPtr("testInstance")
 				listProviderTypesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.XRequestID = core.StringPtr("testString")
 				listProviderTypesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}


### PR DESCRIPTION
## PR summary
* Adding the ability to change the profile_version in the struct ReplaceProfileOptions
* Adding instance_id as part of the path for `provider_types`

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->