### PR TITLE
fix: Add InstanceID to func GetProviderTypeByIdOptions

### DIFF
--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -3188,7 +3188,8 @@ func (securityAndComplianceCenterApi *SecurityAndComplianceCenterApiV3) GetProvi
 	builder := core.NewRequestBuilder(core.GET)
 	builder = builder.WithContext(ctx)
 	builder.EnableGzipCompression = securityAndComplianceCenterApi.GetEnableGzipCompression()
-	_, err = builder.ResolveRequestURL(securityAndComplianceCenterApi.Service.Options.URL, `/v3/provider_types/{provider_type_id}`, pathParamsMap)
+	instanceURL, err := getInstanceBasedURL(securityAndComplianceCenterApi.Service.Options.URL, *getProviderTypeByIdOptions.InstanceID)
+	_, err = builder.ResolveRequestURL(instanceURL, `/provider_types/{provider_type_id}`, pathParamsMap)
 	if err != nil {
 		return
 	}

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3.go
@@ -6654,6 +6654,9 @@ func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfil
 
 // GetProviderTypeByIdOptions : The GetProviderTypeByID options.
 type GetProviderTypeByIdOptions struct {
+	// ID of the instance
+	InstanceID *string `json:"instance_id" validate:"required,ne="`
+
 	// The provider type ID.
 	ProviderTypeID *string `json:"provider_type_id" validate:"required,ne="`
 
@@ -6672,10 +6675,17 @@ type GetProviderTypeByIdOptions struct {
 }
 
 // NewGetProviderTypeByIdOptions : Instantiate GetProviderTypeByIdOptions
-func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeByIdOptions(providerTypeID string) *GetProviderTypeByIdOptions {
+func (*SecurityAndComplianceCenterApiV3) NewGetProviderTypeByIdOptions(instanceID, providerTypeID string) *GetProviderTypeByIdOptions {
 	return &GetProviderTypeByIdOptions{
+		InstanceID:     core.StringPtr(instanceID),
 		ProviderTypeID: core.StringPtr(providerTypeID),
 	}
+}
+
+// SetInstanceID : Allow user to set InstanceID
+func (_options *GetProviderTypeByIdOptions) SetInstanceID(instanceID string) *GetProviderTypeByIdOptions {
+	_options.InstanceID = core.StringPtr(instanceID)
+	return _options
 }
 
 // SetProviderTypeID : Allow user to set ProviderTypeID

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -1631,11 +1631,12 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 			updateProviderTypeInstanceOptions := &securityandcompliancecenterapiv3.UpdateProviderTypeInstanceOptions{
 				ProviderTypeID:         &providerTypeIdLink,
 				ProviderTypeInstanceID: &providerTypeInstanceIdLink,
-				Name:                   core.StringPtr("workload-protection-instance-1"),
-				Attributes:             map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
-				XCorrelationID:         core.StringPtr("testString"),
-				XRequestID:             core.StringPtr("testString"),
-				InstanceID:             core.StringPtr(instanceID),
+				Name:                   core.StringPtr("caveonix-instance-1"),
+				// Attributes:             map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
+				Attributes:     map[string]interface{}{},
+				XCorrelationID: core.StringPtr("testString"),
+				XRequestID:     core.StringPtr("testString"),
+				InstanceID:     core.StringPtr(instanceID),
 			}
 
 			providerTypeInstanceItem, response, err := securityAndComplianceCenterApiService.UpdateProviderTypeInstance(updateProviderTypeInstanceOptions)

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -1531,7 +1531,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 
 			// Manual change: save the ID for the provider type "workload-protection"
 			for _, providerType := range providerTypesCollection.ProviderTypes {
-				if *providerType.Name == "workload-protection" {
+				if *providerType.Name == "Caveonix" {
 					providerTypeIdLink = *providerType.ID
 					fmt.Fprintf(GinkgoWriter, "Saved providerTypeIdLink value: %v\n", providerTypeIdLink)
 					break
@@ -1585,8 +1585,9 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		It(`CreateProviderTypeInstance(createProviderTypeInstanceOptions *CreateProviderTypeInstanceOptions)`, func() {
 			createProviderTypeInstanceOptions := &securityandcompliancecenterapiv3.CreateProviderTypeInstanceOptions{
 				ProviderTypeID: &providerTypeIdLink,
-				Name:           core.StringPtr("workload-protection-instance-1"),
-				Attributes:     map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
+				Name:           core.StringPtr("caveonix-instance-1"),
+				// Attributes:     map[string]interface{}{"wp_crn": "crn:v1:staging:public:sysdig-secure:us-south:a/ff88f007f9ff4622aac4fbc0eda36255:0df4004c-fb74-483b-97be-dd9bd35af4d8::"},
+				Attributes:     map[string]interface{}{},
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),
 				InstanceID:     core.StringPtr(instanceID),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_integration_test.go
@@ -1546,6 +1546,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3 Integration Tests`, func() {
 		})
 		It(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions)`, func() {
 			getProviderTypeByIdOptions := &securityandcompliancecenterapiv3.GetProviderTypeByIdOptions{
+				InstanceID:     core.StringPtr(instanceID),
 				ProviderTypeID: &providerTypeIdLink,
 				XCorrelationID: core.StringPtr("testString"),
 				XRequestID:     core.StringPtr("testString"),

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -11824,7 +11824,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions) - Operation response error`, func() {
-		getProviderTypeByIDPath := "instances/testInstance/v3/provider_types/testString"
+		getProviderTypeByIDPath := "/instances/testInstance/v3/provider_types/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -11824,7 +11824,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions) - Operation response error`, func() {
-		getProviderTypeByIDPath := "/v3/provider_types/testString"
+		getProviderTypeByIDPath := "instances/testInstance/v3/provider_types/testString"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -11876,7 +11876,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 		})
 	})
 	Describe(`GetProviderTypeByID(getProviderTypeByIdOptions *GetProviderTypeByIdOptions)`, func() {
-		getProviderTypeByIDPath := "/v3/provider_types/testString"
+		getProviderTypeByIDPath := "/instances/testInstance/v3/provider_types/testString"
 		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
+++ b/v5/securityandcompliancecenterapiv3/security_and_compliance_center_api_v3_test.go
@@ -11852,6 +11852,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				getProviderTypeByIdOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeByIdOptions)
+				getProviderTypeByIdOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeByIdOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11909,6 +11910,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				getProviderTypeByIdOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeByIdOptions)
+				getProviderTypeByIdOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeByIdOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11974,6 +11976,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				getProviderTypeByIdOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeByIdOptions)
+				getProviderTypeByIdOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeByIdOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XRequestID = core.StringPtr("testString")
@@ -11995,6 +11998,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				getProviderTypeByIdOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeByIdOptions)
+				getProviderTypeByIdOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeByIdOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XRequestID = core.StringPtr("testString")
@@ -12038,6 +12042,7 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				getProviderTypeByIdOptionsModel := new(securityandcompliancecenterapiv3.GetProviderTypeByIdOptions)
+				getProviderTypeByIdOptionsModel.InstanceID = core.StringPtr("testInstance")
 				getProviderTypeByIdOptionsModel.ProviderTypeID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getProviderTypeByIdOptionsModel.XRequestID = core.StringPtr("testString")
@@ -13956,7 +13961,8 @@ var _ = Describe(`SecurityAndComplianceCenterApiV3`, func() {
 			It(`Invoke NewGetProviderTypeByIdOptions successfully`, func() {
 				// Construct an instance of the GetProviderTypeByIdOptions model
 				providerTypeID := "testString"
-				getProviderTypeByIdOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypeByIdOptions(providerTypeID)
+				instanceID := "testInstance"
+				getProviderTypeByIdOptionsModel := securityAndComplianceCenterApiService.NewGetProviderTypeByIdOptions(instanceID, providerTypeID)
 				getProviderTypeByIdOptionsModel.SetProviderTypeID("testString")
 				getProviderTypeByIdOptionsModel.SetXCorrelationID("testString")
 				getProviderTypeByIdOptionsModel.SetXRequestID("testString")


### PR DESCRIPTION
- API endpoint changed for the func `GetProviderTypeByID` which now relies on `instanceID`
- Incorporate field InstanceID which is now required.

## PR summary
Adding InstanceID as a necessary requirement when calling GetProviderTypeOptions

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->